### PR TITLE
Select order status

### DIFF
--- a/common/src/Admin.php
+++ b/common/src/Admin.php
@@ -8,8 +8,8 @@ class Admin {
 
     protected function get_default_config() {
         return [
-            'invite_delay'     => 3,
-            'javascript'       => true,
+            'invite_delay' => 3,
+            'javascript' => true,
             'order_status' => 'wc-completed',
         ];
     }

--- a/common/src/Admin.php
+++ b/common/src/Admin.php
@@ -10,6 +10,7 @@ class Admin {
         return [
             'invite_delay'     => 3,
             'javascript'       => true,
+            'order_status' => 'wc-completed',
         ];
     }
 
@@ -69,6 +70,7 @@ class Admin {
             'invite_delay' => 'intval',
             'limit_order_data' => 'intval',
             'javascript' => 'boolval',
+            'order_status' => 'strval',
             'rich_snippet' => 'boolval',
         ];
 
@@ -127,12 +129,12 @@ class Admin {
         foreach ($errors as $error) {
             ?>
             <div class="error"><p>
-                <?php sprintf(
-                __('An error occurred while requesting the %s invitation:', 'webwinkelkeur'),
-                $this->plugin->getName()
-            ); ?><br/>
-                <?php echo esc_html($error->response); ?>
-            </p></div>
+                    <?php sprintf(
+                        __('An error occurred while requesting the %s invitation:', 'webwinkelkeur'),
+                        $this->plugin->getName()
+                    ); ?><br/>
+                    <?php echo esc_html($error->response); ?>
+                </p></div>
             <?php
         }
 

--- a/common/src/Admin.php
+++ b/common/src/Admin.php
@@ -6,13 +6,13 @@ class Admin {
 
     private $woocommerce = false;
 
-    const ORDER_STATUS = ['wc-completed'];
+    const DEFAULT_ORDER_STATUS = ['wc-completed'];
 
     protected function get_default_config() {
         return [
             'invite_delay' => 3,
             'javascript' => true,
-            'order_statuses' => self::ORDER_STATUS,
+            'order_statuses' => self::DEFAULT_ORDER_STATUS,
         ];
     }
 

--- a/common/src/Admin.php
+++ b/common/src/Admin.php
@@ -10,7 +10,7 @@ class Admin {
         return [
             'invite_delay' => 3,
             'javascript' => true,
-            'order_status' => 'wc-completed',
+            'order_statuses' => ['wc-completed'],
         ];
     }
 
@@ -70,7 +70,9 @@ class Admin {
             'invite_delay' => 'intval',
             'limit_order_data' => 'intval',
             'javascript' => 'boolval',
-            'order_status' => 'strval',
+            'order_statuses' => function ($value) {
+                return $value;
+            },
             'rich_snippet' => 'boolval',
         ];
 
@@ -79,7 +81,7 @@ class Admin {
         foreach (array_keys($fields) as $field_name) {
             $value = get_option($this->plugin->getOptionName($field_name), false);
             if ($value !== false) {
-                $config[$field_name] = (string) $value;
+                $config[$field_name] = $value;
             } elseif (!isset($config[$field_name])) {
                 $config[$field_name] = '';
             }
@@ -89,7 +91,7 @@ class Admin {
             foreach ($fields as $field_name => $sanitize) {
                 try {
                     $config[$field_name] =
-                        $sanitize((string) @$_POST[$this->plugin->getOptionName($field_name)]);
+                        $sanitize(@$_POST[$this->plugin->getOptionName($field_name)]);
                 } catch (ValidationException $e) {
                     $errors[] = $e->getMessage();
                     $config[$field_name] = '';

--- a/common/src/Admin.php
+++ b/common/src/Admin.php
@@ -71,7 +71,11 @@ class Admin {
             'limit_order_data' => 'intval',
             'javascript' => 'boolval',
             'order_statuses' => function ($value) {
-                return $value;
+                $statuses = [];
+                foreach ($value as $status){
+                    $statuses[]= strval($status);
+                }
+                return $statuses;
             },
             'rich_snippet' => 'boolval',
         ];

--- a/common/src/Admin.php
+++ b/common/src/Admin.php
@@ -71,11 +71,7 @@ class Admin {
             'limit_order_data' => 'intval',
             'javascript' => 'boolval',
             'order_statuses' => function ($value) {
-                $statuses = [];
-                foreach ($value as $status) {
-                    $statuses[] = strval($status);
-                }
-                return $statuses;
+                return array_map('strval', is_array($value) ? $value : []);
             },
             'rich_snippet' => 'boolval',
         ];

--- a/common/src/Admin.php
+++ b/common/src/Admin.php
@@ -72,8 +72,8 @@ class Admin {
             'javascript' => 'boolval',
             'order_statuses' => function ($value) {
                 $statuses = [];
-                foreach ($value as $status){
-                    $statuses[]= strval($status);
+                foreach ($value as $status) {
+                    $statuses[] = strval($status);
                 }
                 return $statuses;
             },

--- a/common/src/Admin.php
+++ b/common/src/Admin.php
@@ -6,11 +6,13 @@ class Admin {
 
     private $woocommerce = false;
 
+    const ORDER_STATUS = ['wc-completed'];
+
     protected function get_default_config() {
         return [
             'invite_delay' => 3,
             'javascript' => true,
-            'order_statuses' => ['wc-completed'],
+            'order_statuses' => self::ORDER_STATUS,
         ];
     }
 

--- a/common/src/BasePlugin.php
+++ b/common/src/BasePlugin.php
@@ -98,4 +98,8 @@ abstract class BasePlugin {
         $reflect = new ReflectionClass($this);
         return dirname(dirname($reflect->getFilename())) . '/' . $this->getSlug() . '.php';
     }
+
+    public function isWoocommerceActivated(): bool {
+        return class_exists('woocommerce');
+    }
 }

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -17,7 +17,8 @@ class WooCommerce {
     }
 
     public function orderStatusChanged(int $order_id, string $old_status, string $new_status): void {
-        if ('wc-' . $new_status == (string) get_option($this->plugin->getOptionName('order_status'))) {
+       $selected_status = get_option($this->plugin->getOptionName('order_status')) ?? 'wc-completed';
+        if ($new_status == preg_replace('/^wc-/', '', $selected_status)) {
             $this->sendInvite($order_id);
         }
     }

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -17,7 +17,7 @@ class WooCommerce {
     }
 
     public function orderStatusChanged(int $order_id, string $old_status, string $new_status): void {
-       $selected_status = get_option($this->plugin->getOptionName('order_status')) ?? 'wc-completed';
+        $selected_status = get_option($this->plugin->getOptionName('order_status')) ?: 'wc-completed';
         if ($new_status == preg_replace('/^wc-/', '', $selected_status)) {
             $this->sendInvite($order_id);
         }

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -212,7 +212,7 @@ class WooCommerce {
     }
 
     private function statusReached(string $new_status): bool {
-        $selected_statuses = get_option($this->plugin->getOptionName('order_statuses')) ?: ADMIN::ORDER_STATUS;
+        $selected_statuses = get_option($this->plugin->getOptionName('order_statuses')) ?: Admin::DEFAULT_ORDER_STATUS;
         foreach ($selected_statuses as $selected_status) {
             if ($new_status == preg_replace('/^wc-/', '', $selected_status)) {
                 return true;

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -212,7 +212,7 @@ class WooCommerce {
     }
 
     private function statusReached(string $new_status): bool {
-        $selected_statuses = get_option($this->plugin->getOptionName('order_statuses')) ?: ['wc-completed'];
+        $selected_statuses = get_option($this->plugin->getOptionName('order_statuses')) ?: ADMIN::ORDER_STATUS;
         foreach ($selected_statuses as $selected_status) {
             if ($new_status == preg_replace('/^wc-/', '', $selected_status)) {
                 return true;

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -16,7 +16,7 @@ class WooCommerce {
         add_action('woocommerce_checkout_update_order_meta', [$this, 'set_order_language']);
     }
 
-    public function orderStatusChanged($order_id, $old_status, $new_status) {
+    public function orderStatusChanged(int $order_id, string $old_status, string $new_status): void {
         if ('wc-' . $new_status == (string) get_option($this->plugin->getOptionName('order_status'))) {
             $this->sendInvite($order_id);
         }

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -17,8 +17,7 @@ class WooCommerce {
     }
 
     public function orderStatusChanged(int $order_id, string $old_status, string $new_status): void {
-        $selected_status = get_option($this->plugin->getOptionName('order_status')) ?: 'wc-completed';
-        if ($new_status == preg_replace('/^wc-/', '', $selected_status)) {
+        if ($this->statusReached($new_status)) {
             $this->sendInvite($order_id);
         }
     }
@@ -73,7 +72,7 @@ class WooCommerce {
 
         $invoice_address = $order->get_address('billing');
         $customer_name = $invoice_address['first_name']
-                         . ' ' . $invoice_address['last_name'];
+            . ' ' . $invoice_address['last_name'];
 
         $delivery_address = $order->get_address('shipping');
         $phones = [
@@ -210,5 +209,15 @@ class WooCommerce {
             throw new RuntimeException('Method requires parameters');
         }
         return @$method->invoke($obj);
+    }
+
+    private function statusReached(string $new_status): bool {
+        $selected_statuses = get_option($this->plugin->getOptionName('order_statuses')) ?: ['wc-completed'];
+        foreach ($selected_statuses as $selected_status) {
+            if ($new_status == preg_replace('/^wc-/', '', $selected_status)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -12,8 +12,14 @@ class WooCommerce {
 
     public function __construct(BasePlugin $plugin) {
         $this->plugin = $plugin;
-        add_action('woocommerce_order_status_completed', [$this, 'order_completed'], 10, 1);
+        add_action('woocommerce_order_status_changed', [$this, 'orderStatusChanged'], 10, 3);
         add_action('woocommerce_checkout_update_order_meta', [$this, 'set_order_language']);
+    }
+
+    public function orderStatusChanged($order_id, $old_status, $new_status) {
+        if ('wc-' . $new_status == (string) get_option($this->plugin->getOptionName('order_status'))) {
+            $this->sendInvite($order_id);
+        }
     }
 
     public function set_order_language($order_id) {
@@ -22,7 +28,7 @@ class WooCommerce {
         }
     }
 
-    public function order_completed($order_id) {
+    private function sendInvite($order_id) {
         global $wpdb, $wp_version;
 
         // invites enabled?

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -79,14 +79,20 @@
                     <?php endif; ?>
                     <fieldset>
                         <br>
-                        <label> <?php _e('Select order status', 'webwinkelkeur'); ?>
-                            <select name="<?= $plugin->getOptionName('order_status'); ?>">
-                                <?php foreach (wc_get_order_statuses() as $key => $label): ?>
-                                    <option value="<?= $key; ?>" <?= $key == $config['order_status'] ? 'selected' : ''; ?>><?= $label ?>
-                                    </option>
-                                <? endforeach; ?>
-                            </select>
-                        </label>
+                        <label>Select Order status:</label>
+                        <div class="well well-sm" style="height: 150px; overflow: auto;">
+                            <?php foreach (wc_get_order_statuses() as $key => $label): ?>
+                                <div>
+                                    <label>
+                                        <input type="checkbox" name="<?= $plugin->getOptionName('order_statuses[]'); ?>"
+                                               value="<?= $key; ?>"
+
+                                            <?= in_array($key, $config['order_statuses']) ? 'checked' : ''; ?>>
+                                        <?= $label; ?>
+                                    </label>
+                                </div>
+                            <?php endforeach; ?>
+                        </div>
                         <p class="description">
                             <?php _e('Select an order status on which you would like the invitation to be sent.', 'webwinkelkeur'); ?>
                         </p>

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -77,24 +77,27 @@
                     <?php if (!$plugin->woocommerce): ?>
                     <p class="description"><?php _e('Install and activate WooCommerce to use this functionality.', 'webwinkelkeur'); ?></p>
                     <?php endif; ?>
+                </td>
+            </tr>
+            <tr valign="top">
+                <th scope="row">
+                    <label><?php _e('Order status for invitations', 'webwinkelkeur'); ?></label>
+                </th>
+                <td>
                     <fieldset>
-                        <br>
-                        <label>Select Order status:</label>
-                        <div class="well well-sm" style="height: 150px; overflow: auto;">
+                        <div style="height: 150px; overflow: auto;">
                             <?php foreach (wc_get_order_statuses() as $key => $label): ?>
                                 <div>
                                     <label>
                                         <input type="checkbox" name="<?= $plugin->getOptionName('order_statuses[]'); ?>"
-                                               value="<?= $key; ?>"
-
-                                            <?= in_array($key, $config['order_statuses']) ? 'checked' : ''; ?>>
+                                               value="<?= $key; ?>" <?= in_array($key, $config['order_statuses']) ? 'checked' : ''; ?>>
                                         <?= $label; ?>
                                     </label>
                                 </div>
                             <?php endforeach; ?>
                         </div>
                         <p class="description">
-                            <?php _e('Select an order status on which you would like the invitation to be sent.', 'webwinkelkeur'); ?>
+                            <?php _e('The invitation is only sent when the order has the checked status.', 'webwinkelkeur'); ?>
                         </p>
                     </fieldset>
                 </td>

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -79,10 +79,10 @@
                     <?php endif; ?>
                     <fieldset>
                         <br>
-                        <label for="<?= $plugin->getOptionName('order_status'); ?>"> <?php _e('Select order status', 'webwinkelkeur'); ?>
+                        <label> <?php _e('Select order status', 'webwinkelkeur'); ?>
                             <select name="<?= $plugin->getOptionName('order_status'); ?>">
                                 <?php foreach (wc_get_order_statuses() as $key => $label): ?>
-                                    <option value="<?= $key; ?>" <?= ($key == $config['order_status']) ? ' selected="selected"' : ''; ?>><?= _e($label, 'webwinkelkeur'); ?>
+                                    <option value="<?= $key; ?>" <?= $key == $config['order_status'] ? 'selected' : ''; ?>><?= $label ?>
                                     </option>
                                 <? endforeach; ?>
                             </select>

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -88,11 +88,9 @@
                         <div style="height: 150px; overflow: auto;">
                             <?php foreach (wc_get_order_statuses() as $key => $label): ?>
                                 <div>
-                                    <label>
-                                        <input type="checkbox" name="<?= $plugin->getOptionName('order_statuses[]'); ?>"
-                                               value="<?= $key; ?>" <?= in_array($key, $config['order_statuses']) ? 'checked' : ''; ?>>
-                                        <?= $label; ?>
-                                    </label>
+                                    <input type="checkbox" name="<?= $plugin->getOptionName('order_statuses[]'); ?>"
+                                           value="<?= $key; ?>" <?= in_array($key, $config['order_statuses']) ? 'checked' : ''; ?>>
+                                    <?= $label; ?>
                                 </div>
                             <?php endforeach; ?>
                         </div>

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -87,13 +87,11 @@
                     <fieldset>
                         <div style="height: 150px; overflow: auto;">
                             <?php foreach (wc_get_order_statuses() as $key => $label): ?>
-                                <div>
-                                    <label>
-                                        <input type="checkbox" name="<?= $plugin->getOptionName('order_statuses[]'); ?>"
-                                               value="<?= $key; ?>" <?= in_array($key, $config['order_statuses']) ? 'checked' : ''; ?>>
-                                        <?= $label; ?>
-                                    </label>
-                                </div>
+                                <label>
+                                    <input type="checkbox" name="<?= $plugin->getOptionName('order_statuses[]'); ?>"
+                                           value="<?= $key; ?>" <?= in_array($key, $config['order_statuses']) ? 'checked' : ''; ?>>
+                                    <?= $label; ?>
+                                </label> <br>
                             <?php endforeach; ?>
                         </div>
                         <p class="description">

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -77,6 +77,20 @@
                     <?php if (!$plugin->woocommerce): ?>
                     <p class="description"><?php _e('Install and activate WooCommerce to use this functionality.', 'webwinkelkeur'); ?></p>
                     <?php endif; ?>
+                    <fieldset>
+                        <br>
+                        <label for="<?= $plugin->getOptionName('order_status'); ?>"> <?php _e('Select order status', 'webwinkelkeur'); ?>
+                            <select name="<?= $plugin->getOptionName('order_status'); ?>">
+                                <?php foreach (wc_get_order_statuses() as $key => $label): ?>
+                                    <option value="<?= $key; ?>" <?= ($key == $config['order_status']) ? ' selected="selected"' : ''; ?>><?= _e($label, 'webwinkelkeur'); ?>
+                                    </option>
+                                <? endforeach; ?>
+                            </select>
+                        </label>
+                        <p class="description">
+                            <?php _e('Select order status to send invitation', 'webwinkelkeur'); ?>
+                        </p>
+                    </fieldset>
                 </td>
             </tr>
             <tr>

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -88,7 +88,7 @@
                             </select>
                         </label>
                         <p class="description">
-                            <?php _e('Select order status to send invitation', 'webwinkelkeur'); ?>
+                            <?php _e('Select an order status on which you would like the invitation to be sent.', 'webwinkelkeur'); ?>
                         </p>
                     </fieldset>
                 </td>

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -74,9 +74,6 @@
                             <?php _e('No, don\'t send invitations.', 'webwinkelkeur'); ?>
                         </label>
                     </fieldset>
-                    <?php if (!$plugin->woocommerce): ?>
-                    <p class="description"><?php _e('Install and activate WooCommerce to use this functionality.', 'webwinkelkeur'); ?></p>
-                    <?php endif; ?>
                 </td>
             </tr>
             <tr valign="top">
@@ -84,20 +81,24 @@
                     <label><?php _e('Order status for invitations', 'webwinkelkeur'); ?></label>
                 </th>
                 <td>
-                    <fieldset>
-                        <div style="height: 150px; overflow: auto;">
-                            <?php foreach (wc_get_order_statuses() as $key => $label): ?>
-                                <label>
-                                    <input type="checkbox" name="<?= $plugin->getOptionName('order_statuses[]'); ?>"
-                                           value="<?= $key; ?>" <?= in_array($key, $config['order_statuses']) ? 'checked' : ''; ?>>
-                                    <?= $label; ?>
-                                </label> <br>
-                            <?php endforeach; ?>
-                        </div>
-                        <p class="description">
-                            <?php _e('The invitation is only sent when the order has the checked status.', 'webwinkelkeur'); ?>
-                        </p>
-                    </fieldset>
+                    <?php if (!$plugin->isWoocommerceActivated()): ?>
+                        <p class="description"><?php _e('Install and activate WooCommerce to use this functionality.', 'webwinkelkeur'); ?></p>
+                    <?php else: ?>
+                        <fieldset>
+                            <div style="height: 150px; overflow: auto;">
+                                <?php foreach (wc_get_order_statuses() as $key => $label): ?>
+                                    <label>
+                                        <input type="checkbox" name="<?= $plugin->getOptionName('order_statuses[]'); ?>"
+                                               value="<?= $key; ?>" <?= in_array($key, $config['order_statuses']) ? 'checked' : ''; ?>>
+                                        <?= $label; ?>
+                                    </label> <br>
+                                <?php endforeach; ?>
+                            </div>
+                            <p class="description">
+                                <?php _e('The invitation is only sent when the order has the checked status.', 'webwinkelkeur'); ?>
+                            </p>
+                        </fieldset>
+                    <?php endif; ?>
                 </td>
             </tr>
             <tr>

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -88,9 +88,11 @@
                         <div style="height: 150px; overflow: auto;">
                             <?php foreach (wc_get_order_statuses() as $key => $label): ?>
                                 <div>
-                                    <input type="checkbox" name="<?= $plugin->getOptionName('order_statuses[]'); ?>"
-                                           value="<?= $key; ?>" <?= in_array($key, $config['order_statuses']) ? 'checked' : ''; ?>>
-                                    <?= $label; ?>
+                                    <label>
+                                        <input type="checkbox" name="<?= $plugin->getOptionName('order_statuses[]'); ?>"
+                                               value="<?= $key; ?>" <?= in_array($key, $config['order_statuses']) ? 'checked' : ''; ?>>
+                                        <?= $label; ?>
+                                    </label>
                                 </div>
                             <?php endforeach; ?>
                         </div>


### PR DESCRIPTION
https://app.clubhouse.io/webwinkelkeur/story/4671/woocommerce-select-status-for-sending-invitations
Add select order status in the plugin settings for when the invitation should be sent.
`Completed` status should be the default value.
We've had multiple cases where customers do not use the status **Completed** or they use 3rd party plugins like `MyParcel` or `Woocommerce Order Status Manager` which add custom statuses for finishing the order.

I encountered two problems:
 - https://github.com/webwinkelkeur/wordpress/blob/228b7d76dc6849705fc7d736da5b50e64977bd7f/common/templates/options.php#L84
`wc_get_order_statuses` returns the status with a `wc-` prefix. On the other hand, the new status in `woocommerce_order_status_changed ` returns the name without this prefix https://github.com/webwinkelkeur/wordpress/blob/228b7d76dc6849705fc7d736da5b50e64977bd7f/common/src/WooCommerce.php#L19 

- I could not find if it's possible to get only `$new_status`

[ch4671]