### PR TITLE
Fix retrieving product thumb URL

### DIFF
--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -261,19 +261,13 @@ class WooCommerce {
                 'id' => $product->get_id(),
                 'name' => $product->get_name(),
                 'url' => get_permalink($product->get_id()),
-                'image_url' => $this->getProductImage($product),
+                'image_url' => get_the_post_thumbnail_url($product->get_id()) ?: null,
                 'sku' => $product->get_sku(),
                 'gtin' => $gtin_handler->getGtin(),
                 'reviews_allowed' => $product->get_reviews_allowed(),
             ];
         }
         return $products;
-    }
-
-    private function getProductImage(WC_Product $product) {
-        foreach (get_attached_media('image', $product->get_id()) as $image) {
-            return wp_get_attachment_image_src($image->ID, 'full')[0] ?? null;
-        }
     }
 
     public function syncReviews(): void {


### PR DESCRIPTION
In our woocommerce test store, http://woocommerce.webwinkelkeurtestshops.nl, `get_attached_media` is always `empty`. 
https://developer.wordpress.org/reference/functions/get_the_post_thumbnail_url/ this seems to do the job.

I could not find a reason wh `get_attached_media` did not work 
> an attachment can only be attached to one post. inserting media into a post's content doesn't attach it to the post, only uploading while editing a post will attach it.

I thought that this might have something to do with it, but I tested with custom products with a gallery, etc.