### PR TITLE
Add order note for successfully created invitations

### DIFF
--- a/common/src/API.php
+++ b/common/src/API.php
@@ -77,6 +77,3 @@ class WebwinkelKeurAPIError extends Exception {
         return $this->url;
     }
 }
-
-class WebwinkelKeurAPIAlreadySentError extends WebwinkelKeurAPIError {
-}

--- a/common/src/API.php
+++ b/common/src/API.php
@@ -50,12 +50,6 @@ class API {
         if (isset($result->status) && $result->status == 'success') {
             return true;
         }
-        if (preg_match('|already sent|', $result->message)) {
-            throw new WebwinkelKeurAPIAlreadySentError($url, $result->message);
-        }
-        if (preg_match('|limit hit|', $result->message)) {
-            throw new WebwinkelKeurAPIAlreadySentError($url, $result->message);
-        }
         throw new WebwinkelKeurAPIError(
             $url,
             isset($result->message) ? $result->message : $response->body

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -150,7 +150,7 @@ class WooCommerce {
         $this->insert_comment(
             $order_id,
             sprintf(
-                __('An invitation was added to %s dashboard.', 'webwinkelkeur'),
+                __('An invitation was sent to %s dashboard.', 'webwinkelkeur'),
                 $this->plugin->getName()
             )
         );

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -135,8 +135,6 @@ class WooCommerce {
 
         try {
             $api->invite($data);
-        } catch (WebwinkelKeurAPIAlreadySentError $e) {
-            // that's okay
         } catch (WebwinkelKeurAPIError $e) {
             $this->logApiError($e);
             $this->insert_comment(


### PR DESCRIPTION
https://app.clubhouse.io/webwinkelkeur/story/4814/woocommerce-add-note-when-adding-review-invite-to-queue
Add an order note to indicate that an invitation has been successfully added to the dashboard.

[ch4814]