### PR TITLE
Remove deleted reviews

### DIFF
--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -312,10 +312,15 @@ class WooCommerce {
                 $comment_data['comment_author_email'],
                 (int) $review->review_id
             );
+            $deleted = (int) $review->deleted;
             if ($comment_id) {
                 $comment_data['comment_ID'] = $comment_id;
+                if ($deleted) {
+                    wp_delete_comment($comment_id);
+                    continue;
+                }
                 wp_update_comment($comment_data);
-            } else {
+            } elseif (!$deleted) {
                 wp_insert_comment($comment_data);
             }
         }


### PR DESCRIPTION
`Unapproved` are indicated with a red alert with the count in the `Comments` tab until `approved` or `deleted`. In the current situation, once a review is `deleted` in the dashboard it will remain `unapproved` forever in woocommerce, which means the red alert will remain with it.
This PR :
 - deletes existing reviews when deleted in the dashboard
 - does not insert new review if the review is with status `deleted`