### PR TITLE
Add support for woosa plugin

### DIFF
--- a/common/src/GtinHandler.php
+++ b/common/src/GtinHandler.php
@@ -4,10 +4,13 @@ namespace Valued\WordPress;
 
 class GtinHandler {
     const SUPPORTED_PLUGINS = [
+        'woosa-vandermeer/woosa-vandermeer.php' => ['vdm_ean'],
         'woocommerce-product-feeds/woocommerce-gpf.php' => null,
-        'customer-reviews-woocommerce/ivole.php' => '_cr_gtin',
-        'product-gtin-ean-upc-isbn-for-woocommerce/product-gtin-ean-upc-isbn-for-woocommerce.php' => '_wpm_gtin_code',
-        'woo-product-feed-pro/woocommerce-sea.php' => '_woosea_gtin',
+        'customer-reviews-woocommerce/ivole.php' => ['_cr_gtin'],
+        'product-gtin-ean-upc-isbn-for-woocommerce/product-gtin-ean-upc-isbn-for-woocommerce.php' => [
+            '_wpm_gtin_code', '_wpm_ean_code'
+        ],
+        'woo-product-feed-pro/woocommerce-sea.php' => ['_woosea_gtin', '_woosea_ean'],
     ];
     private $product;
     private $gtin_meta_key;
@@ -33,16 +36,23 @@ class GtinHandler {
         if (is_plugin_active('woocommerce-product-feeds/woocommerce-gpf.php')) {
             return $this->handleGpf();
         }
-        return $this->getGtinFromMeta($this->getGtinMetaKey());
-    }
-
-    private function getGtinMetaKey(): string {
-        foreach (array_filter(self::SUPPORTED_PLUGINS, 'strlen') as $plugin_name => $key) {
+        foreach (
+            array_filter(self::SUPPORTED_PLUGINS, [$this, 'filterPlugins'])
+            as $plugin_name => $keys) {
             if (is_plugin_active($plugin_name)) {
-                return $key;
+                return $this->getFromPluginMeta($keys);
             }
         }
-        return $this->gtin_meta_key;
+        return $this->getGtinFromMeta($this->gtin_meta_key);
+    }
+
+    private function getFromPluginMeta(array $keys): ?string {
+        foreach ($keys as $key) {
+            if ($result = $this->getGtinFromMeta($key)) {
+                return $result;
+            }
+        }
+        return null;
     }
 
     private function getGtinFromMeta(string $key): ?string {
@@ -51,5 +61,9 @@ class GtinHandler {
 
     private function handleGpf(): ?string {
         return (string) woocommerce_gpf_show_element('gtin', $this->product->post) ?: null;
+    }
+
+    private function filterPlugins(?array $value): bool {
+        return !empty($value);
     }
 }

--- a/common/src/GtinHandler.php
+++ b/common/src/GtinHandler.php
@@ -37,7 +37,7 @@ class GtinHandler {
             return $this->handleGpf();
         }
         foreach (
-            array_filter(self::SUPPORTED_PLUGINS, [$this, 'filterPlugins'])
+            array_filter(self::SUPPORTED_PLUGINS, [$this, 'filterMetaPlugins'])
             as $plugin_name => $keys) {
             if (is_plugin_active($plugin_name)) {
                 return $this->getFromPluginMeta($keys);
@@ -63,7 +63,7 @@ class GtinHandler {
         return (string) woocommerce_gpf_show_element('gtin', $this->product->post) ?: null;
     }
 
-    private function filterPlugins(?array $value): bool {
+    private function filterMetaPlugins(?array $value): bool {
         return !empty($value);
     }
 }

--- a/common/src/GtinHandler.php
+++ b/common/src/GtinHandler.php
@@ -36,10 +36,8 @@ class GtinHandler {
         if (is_plugin_active('woocommerce-product-feeds/woocommerce-gpf.php')) {
             return $this->handleGpf();
         }
-        foreach (
-            array_filter(self::SUPPORTED_PLUGINS, [$this, 'filterMetaPlugins'])
-            as $plugin_name => $keys) {
-            if (is_plugin_active($plugin_name)) {
+        foreach (self::SUPPORTED_PLUGINS as $plugin_name => $keys) {
+            if ($keys && is_plugin_active($plugin_name)) {
                 return $this->getFromPluginMeta($keys);
             }
         }
@@ -61,9 +59,5 @@ class GtinHandler {
 
     private function handleGpf(): ?string {
         return (string) woocommerce_gpf_show_element('gtin', $this->product->post) ?: null;
-    }
-
-    private function filterMetaPlugins(?array $value): bool {
-        return !empty($value);
     }
 }


### PR DESCRIPTION
https://app.clubhouse.io/webwinkelkeur/story/4944/testpanel-product-reviews-woocommerce
Add support for **woosa-vandermeer** plugin. woosa-vandermeer adds gtin automatically to products and is popular in the Netherlands.
Some plugins/webshops get their `gtin` value from the `ean` add it to the plugins that support that in case `gtin` is empty

[ch4944]