### PR TITLE
Plugin compatibility

### DIFF
--- a/common/src/API.php
+++ b/common/src/API.php
@@ -17,7 +17,7 @@ class API {
         $this->api_key = (string) $api_key;
     }
 
-    public function getReviews(?string $last_synced): \SimpleXMLElement {
+    public function getReviews(string $last_synced = null): \SimpleXMLElement {
         $params = [
             'id' => $this->shop_id,
             'code' => $this->api_key,

--- a/common/src/GtinHandler.php
+++ b/common/src/GtinHandler.php
@@ -19,7 +19,7 @@ class GtinHandler {
         $this->gtin_meta_key = $gtin_meta_key;
     }
 
-    public function setProduct(\WC_Product $product): void {
+    public function setProduct(\WC_Product $product) {
         $this->product = $product;
     }
 
@@ -32,7 +32,7 @@ class GtinHandler {
         return false;
     }
 
-    public function getGtin(): ?string {
+    public function getGtin() {
         if (is_plugin_active('woocommerce-product-feeds/woocommerce-gpf.php')) {
             return $this->handleGpf();
         }
@@ -44,7 +44,7 @@ class GtinHandler {
         return $this->getGtinFromMeta($this->gtin_meta_key);
     }
 
-    private function getFromPluginMeta(array $keys): ?string {
+    private function getFromPluginMeta(array $keys) {
         foreach ($keys as $key) {
             if ($result = $this->getGtinFromMeta($key)) {
                 return $result;
@@ -53,11 +53,11 @@ class GtinHandler {
         return null;
     }
 
-    private function getGtinFromMeta(string $key): ?string {
+    private function getGtinFromMeta(string $key) {
         return (string) get_post_meta($this->product->get_id(), $key, true) ?: null;
     }
 
-    private function handleGpf(): ?string {
+    private function handleGpf() {
         return (string) woocommerce_gpf_show_element('gtin', $this->product->post) ?: null;
     }
 }

--- a/common/src/PhpCompatibilityCheck.php
+++ b/common/src/PhpCompatibilityCheck.php
@@ -1,23 +1,22 @@
 <?php
-
-
 namespace Valued\WordPress;
-
 
 class PhpCompatibilityCheck {
     public static function isCompatible($plugin_name) {
-        if (version_compare(phpversion(), '7.0.0', '<')) {
-            add_action('admin_notices', function ($arguments) use ($plugin_name) {
-                $class = 'notice notice-error';
-                $message = sprintf(
-                    'The %s plugin is not compatible with PHP %s. Please upgrade to PHP 7.0.0 or higher',
-                    $plugin_name,
-                    phpversion()
-                );
-                printf('<div class="%s"><p>%s</p></div>', esc_attr($class), esc_html($message));
-            });
-            return false;
+        if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
+            return true;
         }
-        return true;
+
+        add_action('admin_notices', function () use ($plugin_name) {
+            $class = 'notice notice-error';
+            $message = sprintf(
+                __('The %s plugin is not compatible with PHP %s. Please upgrade to PHP 7.0.0 or higher.', 'webwinkelkeur'),
+                $plugin_name,
+                PHP_VERSION
+            );
+            printf('<div class="%s"><p>%s</p></div>', esc_attr($class), esc_html($message));
+        });
+
+        return false;
     }
 }

--- a/common/src/PhpCompatibilityCheck.php
+++ b/common/src/PhpCompatibilityCheck.php
@@ -14,7 +14,7 @@ class PhpCompatibilityCheck {
                     $plugin_name,
                     phpversion()
                 );
-                printf('<div class="%1$s"><p>%2$s</p></div>', esc_attr($class), esc_html($message));
+                printf('<div class="%s"><p>%s</p></div>', esc_attr($class), esc_html($message));
             });
             return false;
         }

--- a/common/src/PhpCompatibilityCheck.php
+++ b/common/src/PhpCompatibilityCheck.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace Valued\WordPress;
+
+
+class PhpCompatibilityCheck {
+    public static function isCompatible($plugin_name) {
+        if (version_compare(phpversion(), '7.0.0', '<')) {
+            add_action('admin_notices', function ($arguments) use ($plugin_name) {
+                $class = 'notice notice-error';
+                $message = sprintf(
+                    'The %s plugin is not compatible with PHP %s. Please upgrade to PHP 7.0.0 or higher',
+                    $plugin_name,
+                    phpversion()
+                );
+                printf('<div class="%1$s"><p>%2$s</p></div>', esc_attr($class), esc_html($message));
+            });
+            return false;
+        }
+        return true;
+    }
+}

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -32,7 +32,7 @@ class WooCommerce {
         wp_clear_scheduled_hook($this->getReviewsHook());
     }
 
-    public function orderStatusChanged(int $order_id, string $old_status, string $new_status): void {
+    public function orderStatusChanged(int $order_id, string $old_status, string $new_status) {
         if ($this->statusReached($new_status)) {
             $this->sendInvite($order_id);
         }
@@ -277,7 +277,7 @@ class WooCommerce {
         return $products;
     }
 
-    public function syncReviews(): void {
+    public function syncReviews() {
         if (!get_option($this->plugin->getOptionName('product_reviews'))
             || !$this->plugin->isWoocommerceActivated()
         ) {
@@ -301,7 +301,7 @@ class WooCommerce {
         }
     }
 
-    private function processReviews(\SimpleXMLElement $reviews): void {
+    private function processReviews(\SimpleXMLElement $reviews) {
         foreach ($reviews as $review) {
             $comment_data = $this->getCommentData($review);
             if (empty($comment_data)) {
@@ -326,7 +326,7 @@ class WooCommerce {
         }
     }
 
-    private function getExistingComment(int $post_id, string $author_email, int $review_id): ?int {
+    private function getExistingComment(int $post_id, string $author_email, int $review_id) {
         $args = [
             'post_id' => $post_id,
             'author_email' => $author_email,
@@ -341,7 +341,7 @@ class WooCommerce {
         return $comments[0]->comment_ID ?? null;
     }
 
-    private function getCommentData(\SimpleXMLElement $review): ?array {
+    private function getCommentData(\SimpleXMLElement $review) {
         $pf = new WC_Product_Factory();
         $product_id = (int) $review->products->product->external_id;
         if (!$pf->get_product($product_id)) {
@@ -365,7 +365,7 @@ class WooCommerce {
         ];
     }
 
-    private function logApiError(WebwinkelKeurAPIError $e): void {
+    private function logApiError(WebwinkelKeurAPIError $e) {
         global $wpdb;
         $wpdb->insert($this->plugin->getInviteErrorsTable(), [
             'url' => $e->getURL(),

--- a/trustprofile/trustprofile.php
+++ b/trustprofile/trustprofile.php
@@ -11,7 +11,16 @@ WC tested up to: 4.99
 
 namespace TrustProfile\WordPress;
 
-require __DIR__ . '/common/autoload.php';
-require __DIR__ . '/src/Plugin.php';
+namespace WebwinkelKeur\WordPress;
 
+
+use Valued\WordPress\PhpCompatibilityCheck;
+require __DIR__ . '/common/autoload.php';
+
+if (!PhpCompatibilityCheck::isCompatible('trustprofile')) {
+    return;
+}
+
+require __DIR__ . '/src/Plugin.php';
 Plugin::getInstance()->init();
+

--- a/trustprofile/trustprofile.php
+++ b/trustprofile/trustprofile.php
@@ -11,8 +11,8 @@ WC tested up to: 4.99
 
 namespace TrustProfile\WordPress;
 
-
 use Valued\WordPress\PhpCompatibilityCheck;
+
 require __DIR__ . '/common/autoload.php';
 
 if (!PhpCompatibilityCheck::isCompatible('TrustProfile')) {
@@ -21,4 +21,3 @@ if (!PhpCompatibilityCheck::isCompatible('TrustProfile')) {
 
 require __DIR__ . '/src/Plugin.php';
 Plugin::getInstance()->init();
-

--- a/trustprofile/trustprofile.php
+++ b/trustprofile/trustprofile.php
@@ -17,7 +17,7 @@ namespace WebwinkelKeur\WordPress;
 use Valued\WordPress\PhpCompatibilityCheck;
 require __DIR__ . '/common/autoload.php';
 
-if (!PhpCompatibilityCheck::isCompatible('trustprofile')) {
+if (!PhpCompatibilityCheck::isCompatible('TrustProfile')) {
     return;
 }
 

--- a/trustprofile/trustprofile.php
+++ b/trustprofile/trustprofile.php
@@ -11,8 +11,6 @@ WC tested up to: 4.99
 
 namespace TrustProfile\WordPress;
 
-namespace WebwinkelKeur\WordPress;
-
 
 use Valued\WordPress\PhpCompatibilityCheck;
 require __DIR__ . '/common/autoload.php';

--- a/webwinkelkeur/webwinkelkeur.php
+++ b/webwinkelkeur/webwinkelkeur.php
@@ -11,8 +11,8 @@ WC tested up to: 4.99
 
 namespace WebwinkelKeur\WordPress;
 
-
 use Valued\WordPress\PhpCompatibilityCheck;
+
 require __DIR__ . '/common/autoload.php';
 
 if (!PhpCompatibilityCheck::isCompatible('WebwinkelKeur')) {
@@ -21,4 +21,3 @@ if (!PhpCompatibilityCheck::isCompatible('WebwinkelKeur')) {
 
 require __DIR__ . '/src/Plugin.php';
 Plugin::getInstance()->init();
-

--- a/webwinkelkeur/webwinkelkeur.php
+++ b/webwinkelkeur/webwinkelkeur.php
@@ -11,7 +11,14 @@ WC tested up to: 4.99
 
 namespace WebwinkelKeur\WordPress;
 
-require __DIR__ . '/common/autoload.php';
-require __DIR__ . '/src/Plugin.php';
 
+use Valued\WordPress\PhpCompatibilityCheck;
+require __DIR__ . '/common/autoload.php';
+
+if (!PhpCompatibilityCheck::isCompatible('webwinkelkeur')) {
+    return;
+}
+
+require __DIR__ . '/src/Plugin.php';
 Plugin::getInstance()->init();
+

--- a/webwinkelkeur/webwinkelkeur.php
+++ b/webwinkelkeur/webwinkelkeur.php
@@ -15,7 +15,7 @@ namespace WebwinkelKeur\WordPress;
 use Valued\WordPress\PhpCompatibilityCheck;
 require __DIR__ . '/common/autoload.php';
 
-if (!PhpCompatibilityCheck::isCompatible('webwinkelkeur')) {
+if (!PhpCompatibilityCheck::isCompatible('WebwinkelKeur')) {
     return;
 }
 


### PR DESCRIPTION
https://app.clubhouse.io/webwinkelkeur/story/5142/ensure-wordpress-plugin-compatibility-with-php-5-6-and-7-0
Ensure compatibility with PHP 5.6.0 and 7.0.0.
- In case PHP version is < 7.0.0 show a notice.
- Make plugin compatible with PHP 7.0.0

tested on PHP `5.6.40`, `7.0.33`, `8` 
 - tested send invitation
 - sidebar
 - products
 - importing reviews

[ch5142] [ch5132]