### PR TITLE
Add custom attributes to GTIN select

### DIFF
--- a/common/src/BasePlugin.php
+++ b/common/src/BasePlugin.php
@@ -104,8 +104,8 @@ abstract class BasePlugin {
         return class_exists('woocommerce');
     }
 
-    public function hasActiveGtinPlugin() {
-        return GtinHandler::hasActivePlugin();
+    public function getActiveGtinPlugin() {
+        return GtinHandler::getActivePlugin();
     }
 
     public function getProductMetaKeys(): array {
@@ -147,7 +147,7 @@ abstract class BasePlugin {
     }
 
     public function getCustomAttributePreffix(): string {
-        return "_{$this->getOptionName('custom_')}";
+        return "_{$this->getOptionName('attr_')}";
     }
 
     public function getCustomAttributeName(string $name) {

--- a/common/src/BasePlugin.php
+++ b/common/src/BasePlugin.php
@@ -138,7 +138,7 @@ abstract class BasePlugin {
                 $product_attr = unserialize($value->type);
                 if (!empty($product_attr)) {
                     foreach ($product_attr as $key => $arr_value) {
-                        $custom_attributes[] = $this->getCustomAttributePreffix() . $arr_value['name'];
+                        $custom_attributes[] = $this->getCustomAttributePrefix() . $arr_value['name'];
                     }
                 }
             }
@@ -146,12 +146,12 @@ abstract class BasePlugin {
         return $custom_attributes;
     }
 
-    public function getCustomAttributePreffix(): string {
+    public function getCustomAttributePrefix(): string {
         return "_{$this->getOptionName('attr_')}";
     }
 
     public function getCustomAttributeName(string $name) {
-        $pattern = sprintf('/^%s(.*)/', $this->getCustomAttributePreffix());
+        $pattern = sprintf('/^%s(.*)/', $this->getCustomAttributePrefix());
         preg_match($pattern, $name, $matches);
         return $matches[1] ?? null;
     }

--- a/common/src/BasePlugin.php
+++ b/common/src/BasePlugin.php
@@ -136,7 +136,7 @@ abstract class BasePlugin {
         global $wpdb;
         $custom_attributes = [];
         $sql = "
-            SELECT meta.meta_id, meta.meta_key as name, meta.meta_value as type 
+            SELECT meta.meta_id, meta.meta_key as name, meta.meta_value 
             FROM {$wpdb->postmeta} meta
             JOIN {$wpdb->posts} posts
             ON meta.post_id = posts.id 
@@ -146,7 +146,7 @@ abstract class BasePlugin {
         $data = $wpdb->get_results($sql);
         if (!empty($data)) {
             foreach ($data as $value) {
-                $product_attr = unserialize($value->type);
+                $product_attr = unserialize($value->meta_value);
                 if (!empty($product_attr)) {
                     foreach ($product_attr as $arr_value) {
                         $custom_attributes[] = [

--- a/common/src/BasePlugin.php
+++ b/common/src/BasePlugin.php
@@ -127,9 +127,10 @@ abstract class BasePlugin {
         $custom_attributes = [];
         $sql = "
             SELECT meta.meta_id, meta.meta_key as name, meta.meta_value as type 
-            FROM " . $wpdb->prefix . "postmeta" . " AS meta, " . $wpdb->prefix . "posts" . " AS posts 
-            WHERE meta.post_id = posts.id 
-            AND posts.post_type LIKE '%product%' 
+            FROM {$wpdb->postmeta} meta
+            JOIN {$wpdb->posts} posts
+            ON meta.post_id = posts.id 
+            WHERE posts.post_type LIKE '%product%' 
             AND meta.meta_key='_product_attributes';";
 
         $data = $wpdb->get_results($sql);

--- a/common/src/BasePlugin.php
+++ b/common/src/BasePlugin.php
@@ -104,7 +104,7 @@ abstract class BasePlugin {
         return class_exists('woocommerce');
     }
 
-    public function hasActiveGtinPlugin(): bool {
+    public function hasActiveGtinPlugin() {
         return GtinHandler::hasActivePlugin();
     }
 

--- a/common/src/BasePlugin.php
+++ b/common/src/BasePlugin.php
@@ -140,7 +140,7 @@ abstract class BasePlugin {
             FROM {$wpdb->postmeta} meta
             JOIN {$wpdb->posts} posts
             ON meta.post_id = posts.id 
-            WHERE posts.post_type LIKE '%product%' 
+            WHERE posts.post_type = 'product' 
             AND meta.meta_key='_product_attributes';";
 
         $data = $wpdb->get_results($sql);

--- a/common/src/BasePlugin.php
+++ b/common/src/BasePlugin.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Valued\WordPress;
 
 use ReflectionClass;

--- a/common/src/BasePlugin.php
+++ b/common/src/BasePlugin.php
@@ -134,10 +134,10 @@ abstract class BasePlugin {
 
         $data = $wpdb->get_results($sql);
         if (!empty($data)) {
-            foreach ($data as $key => $value) {
+            foreach ($data as $value) {
                 $product_attr = unserialize($value->type);
                 if (!empty($product_attr)) {
-                    foreach ($product_attr as $key => $arr_value) {
+                    foreach ($product_attr as $arr_value) {
                         $custom_attributes[] = $this->getCustomAttributePrefix() . $arr_value['name'];
                     }
                 }

--- a/common/src/GtinHandler.php
+++ b/common/src/GtinHandler.php
@@ -12,6 +12,9 @@ class GtinHandler {
         ],
         'woo-product-feed-pro/woocommerce-sea.php' => ['_woosea_gtin', '_woosea_ean'],
     ];
+    const ATTRIBUTE_PREFIX = 'attr:';
+    const META_PREFIX = 'meta:';
+
     private $product;
     private $gtin_meta_key;
 
@@ -34,7 +37,7 @@ class GtinHandler {
 
     public function getGtin(string $custom_gtin_key = null) {
         if (!empty($custom_gtin_key)) {
-            return $this->getGtinFromMeta($custom_gtin_key);
+            return $this->getGtinFromKey($custom_gtin_key);
         }
         if (is_plugin_active('woocommerce-product-feeds/woocommerce-gpf.php')) {
             return $this->handleGpf();
@@ -62,5 +65,19 @@ class GtinHandler {
 
     private function handleGpf() {
         return (string) woocommerce_gpf_show_element('gtin', $this->product->post) ?: null;
+    }
+
+    private function getGtinFromKey(string $custom_gtin_key) {
+        if (strpos($custom_gtin_key, self::ATTRIBUTE_PREFIX) === 0) {
+            return $this->product->get_attribute(
+                substr($custom_gtin_key, strlen(self::ATTRIBUTE_PREFIX))
+            );
+        }
+        if (strpos($custom_gtin_key, self::META_PREFIX) === 0) {
+            return $this->getGtinFromMeta(
+                substr($custom_gtin_key, strlen(self::META_PREFIX))
+            );
+        }
+        return null;
     }
 }

--- a/common/src/GtinHandler.php
+++ b/common/src/GtinHandler.php
@@ -23,13 +23,13 @@ class GtinHandler {
         $this->product = $product;
     }
 
-    public static function hasActivePlugin(): bool {
+    public static function hasActivePlugin() {
         foreach (self::SUPPORTED_PLUGINS as $plugin_name => $key) {
             if (is_plugin_active($plugin_name)) {
-                return true;
+                return $plugin_name;
             }
         }
-        return false;
+        return null;
     }
 
     public function getGtin(string $custom_gtin_key = null) {

--- a/common/src/GtinHandler.php
+++ b/common/src/GtinHandler.php
@@ -12,8 +12,8 @@ class GtinHandler {
         ],
         'woo-product-feed-pro/woocommerce-sea.php' => ['_woosea_gtin', '_woosea_ean'],
     ];
-    const ATTRIBUTE_PREFIX = 'attr:';
-    const META_PREFIX = 'meta:';
+    const ATTRIBUTE_PREFIX = 'custom_attribute';
+    const META_PREFIX = 'meta_key';
 
     private $product;
     private $gtin_meta_key;

--- a/common/src/GtinHandler.php
+++ b/common/src/GtinHandler.php
@@ -23,7 +23,7 @@ class GtinHandler {
         $this->product = $product;
     }
 
-    public static function hasActivePlugin() {
+    public static function getActivePlugin() {
         foreach (self::SUPPORTED_PLUGINS as $plugin_name => $key) {
             if (is_plugin_active($plugin_name)) {
                 return $plugin_name;

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -261,13 +261,17 @@ class WooCommerce {
             if (!$product) {
                 continue;
             }
+            $gtin_handler = new GtinHandler($this->getGtinMetaKey());
+            $gtin_handler->setProduct($product);
             $products[] = [
                 'id' => $product->get_id(),
                 'name' => $product->get_name(),
                 'url' => get_permalink($product->get_id()),
                 'image_url' => get_the_post_thumbnail_url($product->get_id()) ?: null,
                 'sku' => $product->get_sku(),
-                'gtin' => $this->getProductGtin($product),
+                'gtin' => $gtin_handler->getGtin(
+                    get_option($this->plugin->getOptionName('custom_gtin')) ?: null
+                ),
                 'reviews_allowed' => $product->get_reviews_allowed(),
             ];
         }
@@ -381,16 +385,5 @@ class WooCommerce {
 
     private function getGtinMetaKey(): string {
         return "_{$this->plugin->getOptionName('gtin')}";
-    }
-
-    private function getProductGtin(\WC_Product $product) {
-        if ($custom_gtin = get_option($this->plugin->getOptionName('custom_gtin'))) {
-            if ($custom_attribute = $this->plugin->getCustomAttributeName($custom_gtin)) {
-                return $product->get_attribute($custom_attribute);
-            }
-        }
-        $gtin_handler = new GtinHandler($this->getGtinMetaKey());
-        $gtin_handler->setProduct($product);
-        return $gtin_handler->getGtin($custom_gtin ?: null);
     }
 }

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -157,7 +157,7 @@ class WooCommerce {
     }
 
     public function addGtinOption() {
-        if (GtinHandler::hasActivePlugin() || !get_option($this->plugin->getOptionName('product_reviews'))) {
+        if (GtinHandler::getActivePlugin() || !get_option($this->plugin->getOptionName('product_reviews'))) {
             return;
         }
         $label = 'GTIN';

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -261,17 +261,13 @@ class WooCommerce {
             if (!$product) {
                 continue;
             }
-            $gtin_handler = new GtinHandler($this->getGtinMetaKey());
-            $gtin_handler->setProduct($product);
             $products[] = [
                 'id' => $product->get_id(),
                 'name' => $product->get_name(),
                 'url' => get_permalink($product->get_id()),
                 'image_url' => get_the_post_thumbnail_url($product->get_id()) ?: null,
                 'sku' => $product->get_sku(),
-                'gtin' => $gtin_handler->getGtin(
-                    get_option($this->plugin->getOptionName('custom_gtin')) ?: null
-                ),
+                'gtin' => $this->getGtin($product),
                 'reviews_allowed' => $product->get_reviews_allowed(),
             ];
         }
@@ -385,5 +381,16 @@ class WooCommerce {
 
     private function getGtinMetaKey(): string {
         return "_{$this->plugin->getOptionName('gtin')}";
+    }
+
+    private function getGtin(\WC_Product $product) {
+        if ($custom_gtin = get_option($this->plugin->getOptionName('custom_gtin'))) {
+            if ($custom_attribute = $this->plugin->getCustomAttributeName($custom_gtin)) {
+                return $product->get_attribute($custom_attribute);
+            }
+        }
+        $gtin_handler = new GtinHandler($this->getGtinMetaKey());
+        $gtin_handler->setProduct($product);
+        return $gtin_handler->getGtin($custom_gtin ?: null);
     }
 }

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -267,7 +267,7 @@ class WooCommerce {
                 'url' => get_permalink($product->get_id()),
                 'image_url' => get_the_post_thumbnail_url($product->get_id()) ?: null,
                 'sku' => $product->get_sku(),
-                'gtin' => $this->getGtin($product),
+                'gtin' => $this->getProductGtin($product),
                 'reviews_allowed' => $product->get_reviews_allowed(),
             ];
         }
@@ -383,7 +383,7 @@ class WooCommerce {
         return "_{$this->plugin->getOptionName('gtin')}";
     }
 
-    private function getGtin(\WC_Product $product) {
+    private function getProductGtin(\WC_Product $product) {
         if ($custom_gtin = get_option($this->plugin->getOptionName('custom_gtin'))) {
             if ($custom_attribute = $this->plugin->getCustomAttributeName($custom_gtin)) {
                 return $product->get_attribute($custom_attribute);

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -148,7 +148,7 @@
                     <label>
                         GTIN meta key
                         <select name="<?= $plugin->getOptionName('custom_gtin'); ?>">
-                            <option value=""><?= $plugin->hasActiveGtinPlugin() ? __('Automatic detection', 'webwinkelkeur') : 'Select key'; ?></option>
+                            <option value=""><?= $plugin->hasActiveGtinPlugin() ? __('Automatic detection', 'webwinkelkeur') . ' (' . explode('/', $plugin->hasActiveGtinPlugin())[0] .')' : 'Select key'; ?></option>
                             <?php foreach ($plugin->getProductMetaKeys() as $key): ?>
                                 <option value="<?= $key; ?>" <?= $key == $config['custom_gtin'] ? 'selected' : ''; ?>><?= $plugin->getAttributeName($key); ?></option>
                             <?php endforeach; ?>

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -149,8 +149,9 @@
                         GTIN key
                         <select name="<?= $plugin->getOptionName('custom_gtin'); ?>">
                             <option value=""><?= $plugin->getActiveGtinPlugin() ? __('Automatic detection', 'webwinkelkeur') . ' (' . (explode('/', $plugin->getActiveGtinPlugin())[0] ?? '') . ')' : 'Select key'; ?></option>
-                            <?php foreach ($plugin->getProductMetaKeys() as $key): ?>
-                                <option value="<?= $key; ?>" <?= $key == $config['custom_gtin'] ? 'selected' : ''; ?>><?= $plugin->getAttributeName($key); ?></option>
+                            <?php foreach ($plugin->getProductKeys() as $key): ?>
+                                <?php $option_value = $key['type'] . ':' . $key['name']; ?>
+                                <option value="<?= $option_value; ?>" <?= $option_value == $config['custom_gtin'] ? 'selected' : ''; ?>><?= $key['name']; ?></option>
                             <?php endforeach; ?>
                         </select>
                     </label>

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -146,7 +146,7 @@
                 <th scope="row"></th>
                 <td>
                     <label>
-                        GTIN meta key
+                        GTIN key
                         <select name="<?= $plugin->getOptionName('custom_gtin'); ?>">
                             <option value=""><?= $plugin->getActiveGtinPlugin() ? __('Automatic detection', 'webwinkelkeur') . ' (' . (explode('/', $plugin->getActiveGtinPlugin())[0] ?? '') . ')' : 'Select key'; ?></option>
                             <?php foreach ($plugin->getProductMetaKeys() as $key): ?>

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -150,8 +150,7 @@
                         <select name="<?= $plugin->getOptionName('custom_gtin'); ?>">
                             <option value=""><?= $plugin->getActiveGtinPlugin() ? __('Automatic detection', 'webwinkelkeur') . ' (' . (explode('/', $plugin->getActiveGtinPlugin())[0] ?? '') . ')' : 'Select key'; ?></option>
                             <?php foreach ($plugin->getProductKeys() as $key): ?>
-                                <?php $option_value = $key['type'] . ':' . $key['name']; ?>
-                                <option value="<?= $option_value; ?>" <?= $option_value == $config['custom_gtin'] ? 'selected' : ''; ?>><?= $key['name']; ?></option>
+                                <option value="<?= $key['option_value']; ?>" <?= $key['option_value'] == $config['custom_gtin'] ? 'selected' : ''; ?>><?= $key['label']; ?></option>
                             <?php endforeach; ?>
                         </select>
                     </label>

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -148,7 +148,7 @@
                     <label>
                         GTIN meta key
                         <select name="<?= $plugin->getOptionName('custom_gtin'); ?>">
-                            <option value=""><?= $plugin->hasActiveGtinPlugin() ? __('Automatic detection', 'webwinkelkeur') . ' (' . explode('/', $plugin->hasActiveGtinPlugin())[0] .')' : 'Select key'; ?></option>
+                            <option value=""><?= $plugin->getActiveGtinPlugin() ? __('Automatic detection', 'webwinkelkeur') . ' (' . (explode('/', $plugin->getActiveGtinPlugin())[0] ?? '') . ')' : 'Select key'; ?></option>
                             <?php foreach ($plugin->getProductMetaKeys() as $key): ?>
                                 <option value="<?= $key; ?>" <?= $key == $config['custom_gtin'] ? 'selected' : ''; ?>><?= $plugin->getAttributeName($key); ?></option>
                             <?php endforeach; ?>

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -150,7 +150,7 @@
                         <select name="<?= $plugin->getOptionName('custom_gtin'); ?>">
                             <option value=""><?= $plugin->hasActiveGtinPlugin() ? __('Automatic detection', 'webwinkelkeur') : 'Select key'; ?></option>
                             <?php foreach ($plugin->getProductMetaKeys() as $key): ?>
-                                <option value="<?= $key; ?>" <?= $key == $config['custom_gtin'] ? 'selected' : ''; ?>><?= $key; ?></option>
+                                <option value="<?= $key; ?>" <?= $key == $config['custom_gtin'] ? 'selected' : ''; ?>><?= $plugin->getAttributeName($key); ?></option>
                             <?php endforeach; ?>
                         </select>
                     </label>


### PR DESCRIPTION
https://app.clubhouse.io/webwinkelkeur/story/5351/add-custom-attributes-to-gtin-select
The last `key` in the coffin.
There are webshops that use product attributes for assigning the GTIN/EAN. I looked at how this is handled by other Google merchant related plugins and made something similar.

[ch5351]