### PR TITLE
Remove GTIN field when not needed

### DIFF
--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -157,7 +157,8 @@ class WooCommerce {
     }
 
     public function addGtinOption() {
-        if (GtinHandler::getActivePlugin()
+        if (
+            GtinHandler::getActivePlugin()
             || !get_option($this->plugin->getOptionName('product_reviews'))
             || get_option($this->plugin->getOptionName('custom_gtin'))
         ) {

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -157,7 +157,10 @@ class WooCommerce {
     }
 
     public function addGtinOption() {
-        if (GtinHandler::getActivePlugin() || !get_option($this->plugin->getOptionName('product_reviews'))) {
+        if (GtinHandler::getActivePlugin()
+            || !get_option($this->plugin->getOptionName('product_reviews'))
+            || get_option($this->plugin->getOptionName('custom_gtin'))
+        ) {
             return;
         }
         $label = 'GTIN';


### PR DESCRIPTION
Remove custom GTIN field when the key is autodetected or selected