### PR TITLE
Add examples values in GTIN select

### DIFF
--- a/common/src/BasePlugin.php
+++ b/common/src/BasePlugin.php
@@ -150,19 +150,20 @@ abstract class BasePlugin {
             return [
                 'option_value' => $value['type'] . htmlentities($value['name']),
                 'label' => htmlentities($value['name']) . ' (e.g. "' . $value['example_value'] . '")',
-                'suggested' => $this->isSuggested($value['example_value']),
+                'suggested' => $this->isValidGtin($value['example_value']),
             ];
         },
             $custom_keys
         );
     }
 
-    private function getMetaValue(string $meta_key): string {
+    private function getMetaValue(string $meta_key) {
         global $wpdb;
         $sql = "
             SELECT meta.meta_value
             FROM {$wpdb->postmeta} meta
             WHERE meta.meta_key = '{$meta_key}'
+            AND meta.meta_value <> ''
             LIMIT 1;
         ";
         return $wpdb->get_var($sql);
@@ -211,7 +212,7 @@ abstract class BasePlugin {
         return true;
     }
 
-    private function isSuggested(string $value): bool {
+    private function isValidGtin(string $value): bool {
         return preg_match('/^\d{8}(?:\d{4,6})?$/', $value);
     }
 }

--- a/common/src/BasePlugin.php
+++ b/common/src/BasePlugin.php
@@ -163,7 +163,6 @@ abstract class BasePlugin {
             SELECT meta.meta_value
             FROM {$wpdb->postmeta} meta
             WHERE meta.meta_key = '{$meta_key}'
-            AND meta.meta_value <> ''
             LIMIT 1;
         ";
         return $wpdb->get_var($sql);

--- a/common/src/BasePlugin.php
+++ b/common/src/BasePlugin.php
@@ -120,11 +120,10 @@ abstract class BasePlugin {
         ");
         return array_map(
             function ($value) {
-                $meta_value = substr($this->getMetaValue($value), 0, 15);
                 return [
                     'type' => 'meta_key',
                     'name' => $value,
-                    'example_value' => $meta_value,
+                    'example_value' => substr($this->getMetaValue($value), 0, 15),
                 ];
             },
             $meta_keys
@@ -194,7 +193,7 @@ abstract class BasePlugin {
                 $custom_attributes[] = [
                     'type' => 'custom_attribute',
                     'name' => $arr_value['name'],
-                    'example_value' => $arr_value['value'],
+                    'example_value' => substr($arr_value['value'], 0, 15),
                 ];
             }
         }

--- a/common/src/BasePlugin.php
+++ b/common/src/BasePlugin.php
@@ -131,7 +131,7 @@ abstract class BasePlugin {
         );
     }
 
-    public function getKeysPerSuggestion(string $selected_key, bool $suggested = false) {
+    public function getSelectOptions(string $selected_key, bool $suggested = false) {
         $options = [];
         foreach ($this->getProductKeys() as $key) {
             if ($key['suggested'] != $suggested) {
@@ -142,7 +142,7 @@ abstract class BasePlugin {
         return $options;
     }
 
-    public function getProductKeys() {
+    private function getProductKeys(): array {
         $custom_keys = array_merge($this->getProductMetaKeys(), $this->getCustomAttributes());
         return array_map(function ($value) {
             return [
@@ -155,7 +155,7 @@ abstract class BasePlugin {
         );
     }
 
-    private function getMetaValue($meta_key) {
+    private function getMetaValue(string $meta_key): string {
         global $wpdb;
         $sql = "
             SELECT meta.meta_value
@@ -166,6 +166,7 @@ abstract class BasePlugin {
         ";
         return $wpdb->get_var($sql);
     }
+
     private function getCustomAttributes(): array {
         global $wpdb;
         $custom_attributes = [];
@@ -209,7 +210,7 @@ abstract class BasePlugin {
         return true;
     }
 
-    private function isSuggested($value): bool {
+    private function isSuggested(string $value): bool {
         return preg_match('/^\d{8}(?:\d{4,6})?$/', $value);
     }
 }

--- a/common/src/BasePlugin.php
+++ b/common/src/BasePlugin.php
@@ -147,7 +147,7 @@ abstract class BasePlugin {
         return array_map(function ($value) {
             return [
                 'option_value' => $value['type'] . htmlentities($value['name']),
-                'label' => htmlentities($value['name']) . ' (e.g. ' . $value['example_value'] . ')',
+                'label' => htmlentities($value['name']) . ' (e.g. "' . $value['example_value'] . '")',
                 'suggested' => $this->isSuggested($value['example_value']),
             ];
         },

--- a/common/src/BasePlugin.php
+++ b/common/src/BasePlugin.php
@@ -136,7 +136,10 @@ abstract class BasePlugin {
             if ($key['suggested'] != $suggested) {
                 continue;
             }
-            $options[] = '<option value="' . $key['option_value'] . '" ' . ($key['option_value'] == $selected_key ? 'selected' : '') . '>' . $key['label'] . '</option>';
+            $options[] = '<option value="' . $key['option_value'] . '" '
+                . ($key['option_value'] == $selected_key ? 'selected' : '') . '>'
+                . $key['label']
+                . '</option>';
         }
         return $options;
     }

--- a/common/src/BasePlugin.php
+++ b/common/src/BasePlugin.php
@@ -140,7 +140,7 @@ abstract class BasePlugin {
                 '<option value="%s"%s>%s</option>',
                 htmlentities($key['option_value']),
                 $key['option_value'] === $selected_key ? ' selected' : '',
-                htmlentities($key['label']) . PHP_EOL
+                htmlentities($key['label'])
             );
         }
         return $options;

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -160,7 +160,7 @@ class WooCommerce {
         if (
             GtinHandler::getActivePlugin()
             || !get_option($this->plugin->getOptionName('product_reviews'))
-            || get_option($this->plugin->getOptionName('custom_gtin'))
+            || get_option($this->plugin->getOptionName('custom_gtin') != $this->getGtinMetaKey())
         ) {
             return;
         }

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -146,11 +146,16 @@
                 <th scope="row"></th>
                 <td>
                     <label>
-                        GTIN key
+                        GTIN/EAN key
                         <select name="<?= $plugin->getOptionName('custom_gtin'); ?>">
                             <option value=""><?= $plugin->getActiveGtinPlugin() ? __('Automatic detection', 'webwinkelkeur') . ' (' . (explode('/', $plugin->getActiveGtinPlugin())[0] ?? '') . ')' : 'Select key'; ?></option>
-                            <?php foreach ($plugin->getProductKeys() as $key): ?>
-                                <option value="<?= $key['option_value']; ?>" <?= $key['option_value'] == $config['custom_gtin'] ? 'selected' : ''; ?>><?= $key['label']; ?></option>
+                            <optgroup label="<?= _e('Suggested keys', 'webwinkelkeur'); ?>">
+                                <?php foreach ($plugin->getKeysPerSuggestion($config['custom_gtin'], true) as $select_option): ?>
+                                    <?= $select_option; ?>
+                                <?php endforeach; ?>
+                            </optgroup>
+                            <?php foreach ($plugin->getKeysPerSuggestion($config['custom_gtin']) as $select_option): ?>
+                                <?= $select_option; ?>
                             <?php endforeach; ?>
                         </select>
                     </label>

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -150,14 +150,10 @@
                         <select name="<?= $plugin->getOptionName('custom_gtin'); ?>">
                             <option value=""><?= $plugin->getActiveGtinPlugin() ? __('Automatic detection', 'webwinkelkeur') . ' (' . (explode('/', $plugin->getActiveGtinPlugin())[0] ?? '') . ')' : 'Select key'; ?></option>
                             <optgroup label="<?= _e('Suggested keys', 'webwinkelkeur'); ?>">
-                                <?php foreach ($plugin->getSelectOptions($config['custom_gtin'], true) as $select_option): ?>
-                                    <?= $select_option; ?>
-                                <?php endforeach; ?>
+                                <?= $plugin->getSelectOptions($config['custom_gtin'], true); ?>
                             </optgroup>
                             <optgroup label="<?= _e('Other keys', 'webwinkelkeur'); ?>">
-                                <?php foreach ($plugin->getSelectOptions($config['custom_gtin']) as $select_option): ?>
-                                    <?= $select_option; ?>
-                                <?php endforeach; ?>
+                                <?= $plugin->getSelectOptions($config['custom_gtin']); ?>
                             </optgroup>
                         </select>
                     </label>

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -150,12 +150,12 @@
                         <select name="<?= $plugin->getOptionName('custom_gtin'); ?>">
                             <option value=""><?= $plugin->getActiveGtinPlugin() ? __('Automatic detection', 'webwinkelkeur') . ' (' . (explode('/', $plugin->getActiveGtinPlugin())[0] ?? '') . ')' : 'Select key'; ?></option>
                             <optgroup label="<?= _e('Suggested keys', 'webwinkelkeur'); ?>">
-                                <?php foreach ($plugin->getKeysPerSuggestion($config['custom_gtin'], true) as $select_option): ?>
+                                <?php foreach ($plugin->getSelectOptions($config['custom_gtin'], true) as $select_option): ?>
                                     <?= $select_option; ?>
                                 <?php endforeach; ?>
                             </optgroup>
                             <optgroup label="<?= _e('Other keys', 'webwinkelkeur'); ?>">
-                                <?php foreach ($plugin->getKeysPerSuggestion($config['custom_gtin']) as $select_option): ?>
+                                <?php foreach ($plugin->getSelectOptions($config['custom_gtin']) as $select_option): ?>
                                     <?= $select_option; ?>
                                 <?php endforeach; ?>
                             </optgroup>

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -154,9 +154,11 @@
                                     <?= $select_option; ?>
                                 <?php endforeach; ?>
                             </optgroup>
-                            <?php foreach ($plugin->getKeysPerSuggestion($config['custom_gtin']) as $select_option): ?>
-                                <?= $select_option; ?>
-                            <?php endforeach; ?>
+                            <optgroup label="<?= _e('Other keys', 'webwinkelkeur'); ?>">
+                                <?php foreach ($plugin->getKeysPerSuggestion($config['custom_gtin']) as $select_option): ?>
+                                    <?= $select_option; ?>
+                                <?php endforeach; ?>
+                            </optgroup>
                         </select>
                     </label>
                     <p class="description">


### PR DESCRIPTION
https://app.clubhouse.io/webwinkelkeur/story/5764/improve-select-gtin
Following the discussion in Telegram, selecting a GTIN key is too technical for the webshop owners. To improve that it was decided that instead of the key type in the option label, it is better to show an example value.
In this PR:
 - show only keys with non-empty values
 - show example value in option label
 - separate keys in two groups - `Suggested keys` and `Other keys`
 - suggested keys are keys with values with matching GTIN format.
 - show AddGtin field when `_{plugin}_custom_gtin`  key is selected

[ch5764]