### PR TITLE
Manually sync reviews

### DIFF
--- a/common/src/BasePlugin.php
+++ b/common/src/BasePlugin.php
@@ -218,29 +218,4 @@ abstract class BasePlugin {
     private function isValidGtin(string $value): bool {
         return preg_match('/^\d{8}(?:\d{4,6})?$/', $value);
     }
-
-    public function getManualSyncAction(): string {
-        return $this->getOptionName('manual_sync');
-    }
-
-    public function getManualSyncNonce(): string {
-        return $this->getOptionName('manual-sync-data');
-    }
-
-    public function getNextReviewSync(): string {
-        return $this->getReviewSyncDate(wp_next_scheduled($this->woocommerce->getReviewsHook()));
-    }
-
-    public function getLastReviewSync(): string {
-        return $this->getReviewSyncDate(strtotime(
-            get_option($this->getOptionName('last_synced'))
-        ));
-    }
-
-    private function getReviewSyncDate($date): string {
-        if ($date) {
-            return htmlentities(date("Y-m-d H:i:s", $date));
-        }
-        return 'Not registered.';
-    }
 }

--- a/common/src/BasePlugin.php
+++ b/common/src/BasePlugin.php
@@ -220,11 +220,11 @@ abstract class BasePlugin {
     }
 
     public function getManualSyncAction(): string {
-        return "{$this->getOptionName('manual_sync')}";
+        return $this->getOptionName('manual_sync');
     }
 
     public function getManualSyncNonce(): string {
-        return "{$this->getOptionName('manual-sync-data')}";
+        return $this->getOptionName('manual-sync-data');
     }
 
     public function getNextReviewSync(): string {

--- a/common/src/BasePlugin.php
+++ b/common/src/BasePlugin.php
@@ -227,10 +227,19 @@ abstract class BasePlugin {
         return "{$this->getOptionName('manual-sync-data')}";
     }
 
-    public function getNextReviewSync() {
-        $next_sync = wp_next_scheduled($this->woocommerce->getReviewsHook());
-        if ($next_sync) {
-            return date("Y-m-d H:i:s", $next_sync);
+    public function getNextReviewSync(): string {
+        return $this->getReviewSyncDate(wp_next_scheduled($this->woocommerce->getReviewsHook()));
+    }
+
+    public function getLastReviewSync(): string {
+        return $this->getReviewSyncDate(strtotime(
+            get_option($this->getOptionName('last_synced'))
+        ));
+    }
+
+    private function getReviewSyncDate($date): string {
+        if ($date) {
+            return htmlentities(date("Y-m-d H:i:s", $date));
         }
         return 'Not registered.';
     }

--- a/common/src/BasePlugin.php
+++ b/common/src/BasePlugin.php
@@ -218,4 +218,20 @@ abstract class BasePlugin {
     private function isValidGtin(string $value): bool {
         return preg_match('/^\d{8}(?:\d{4,6})?$/', $value);
     }
+
+    public function getManualSyncAction(): string {
+        return "{$this->getOptionName('manual_sync')}";
+    }
+
+    public function getManualSyncNonce(): string {
+        return "{$this->getOptionName('manual-sync-data')}";
+    }
+
+    public function getNextReviewSync() {
+        $next_sync = wp_next_scheduled($this->woocommerce->getReviewsHook());
+        if ($next_sync) {
+            return date("Y-m-d H:i:s", $next_sync);
+        }
+        return 'Not registered.';
+    }
 }

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -388,7 +388,7 @@ class WooCommerce {
         ]);
     }
 
-    public function getReviewsHook(): string {
+    private function getReviewsHook(): string {
         return "{$this->plugin->getSlug()}_reviews_cron";
     }
 

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -20,7 +20,7 @@ class WooCommerce {
         register_activation_hook($this->plugin->getPluginFile(), [$this, 'activateSyncReviews']);
         register_deactivation_hook($this->plugin->getPluginFile(), [$this, 'deactivateSyncReviews']);
         add_action($this->getReviewsHook(), [$this, 'syncReviews']);
-        add_action('wp_ajax_' . $plugin->getManualSyncAction(), [$this, 'manualReviewSync']);
+        add_action('wp_ajax_' . $this->getManualSyncAction(), [$this, 'manualReviewSync']);
     }
 
     public function activateSyncReviews() {
@@ -284,7 +284,7 @@ class WooCommerce {
     }
 
     public function manualReviewSync() {
-        check_ajax_referer($this->plugin->getManualSyncNonce());
+        check_ajax_referer($this->getManualSyncNonce());
         $this->syncReviews();
         echo json_encode(['status' => true]);
         wp_die();
@@ -395,5 +395,30 @@ class WooCommerce {
 
     private function getGtinMetaKey(): string {
         return "_{$this->plugin->getOptionName('gtin')}";
+    }
+
+    public function getManualSyncAction(): string {
+        return $this->plugin->getOptionName('manual_sync');
+    }
+
+    public function getManualSyncNonce(): string {
+        return $this->plugin->getOptionName('manual-sync-data');
+    }
+
+    public function getNextReviewSync(): string {
+        return $this->getReviewSyncDate(wp_next_scheduled($this->getReviewsHook()));
+    }
+
+    public function getLastReviewSync(): string {
+        return $this->getReviewSyncDate(strtotime(
+            get_option($this->plugin->getOptionName('last_synced'))
+        ));
+    }
+
+    private function getReviewSyncDate($date): string {
+        if ($date) {
+            return htmlentities(date("Y-m-d H:i:s", $date));
+        }
+        return __('Not registered.', 'webwinkelkeur');
     }
 }

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -309,7 +309,10 @@ class WooCommerce {
             return;
         }
         $this->processReviews($reviews);
-        update_option($this->plugin->getOptionName('last_synced'), date(\DateTime::RFC3339));
+        if ($last_modified = (string) ($reviews[0]->modified ?? null)) {
+            update_option($this->plugin->getOptionName('last_synced'), $last_modified);
+        }
+        update_option($this->plugin->getOptionName('last_executed_sync'), date(\DateTime::RFC3339));
     }
 
     private function processReviews(\SimpleXMLElement $reviews) {
@@ -411,7 +414,7 @@ class WooCommerce {
 
     public function getLastReviewSync(): string {
         return $this->getReviewSyncDate(strtotime(
-            get_option($this->plugin->getOptionName('last_synced'))
+            get_option($this->plugin->getOptionName('last_executed_sync'))
         ));
     }
 

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -20,6 +20,7 @@ class WooCommerce {
         register_activation_hook($this->plugin->getPluginFile(), [$this, 'activateSyncReviews']);
         register_deactivation_hook($this->plugin->getPluginFile(), [$this, 'deactivateSyncReviews']);
         add_action($this->getReviewsHook(), [$this, 'syncReviews']);
+        add_action('wp_ajax_' . $plugin->getManualSyncAction(), [$this, 'manualReviewSync']);
     }
 
     public function activateSyncReviews() {
@@ -282,6 +283,13 @@ class WooCommerce {
         return $products;
     }
 
+    public function manualReviewSync() {
+        check_ajax_referer($this->plugin->getManualSyncNonce());
+        $this->syncReviews();
+        echo json_encode(['status' => true]);
+        wp_die();
+    }
+
     public function syncReviews() {
         if (!get_option($this->plugin->getOptionName('product_reviews'))
             || !$this->plugin->isWoocommerceActivated()
@@ -379,7 +387,7 @@ class WooCommerce {
         ]);
     }
 
-    private function getReviewsHook(): string {
+    public function getReviewsHook(): string {
         return "{$this->plugin->getSlug()}_reviews_cron";
     }
 

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -286,7 +286,7 @@ class WooCommerce {
     public function manualReviewSync() {
         check_ajax_referer($this->getManualSyncNonce());
         $this->syncReviews();
-        echo json_encode(['status' => true]);
+        wp_send_json(['status' => true]);
         wp_die();
     }
 

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -309,9 +309,7 @@ class WooCommerce {
             return;
         }
         $this->processReviews($reviews);
-        if ($last_modified = (string) ($reviews[0]->modified ?? null)) {
-            update_option($this->plugin->getOptionName('last_synced'), $last_modified);
-        }
+        update_option($this->plugin->getOptionName('last_synced'), date(\DateTime::RFC3339));
     }
 
     private function processReviews(\SimpleXMLElement $reviews) {

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -149,9 +149,9 @@
                                 <?= __('Synced successfully', 'webwinkelkeur'); ?>
                             </span>
                         </label> </br>
-                        <p> <?= __('Last sync', 'webwinkelkeur'); ?>: <b><?= $plugin->getLastReviewSync(); ?></b>
+                        <p> <?= __('Last sync', 'webwinkelkeur'); ?>: <b><?= $plugin->woocommerce->getLastReviewSync(); ?></b>
                         </p>
-                        <p> <?= __('Next sync', 'webwinkelkeur'); ?>: <b><?= $plugin->getNextReviewSync(); ?></b>
+                        <p> <?= __('Next sync', 'webwinkelkeur'); ?>: <b><?= $plugin->woocommerce->getNextReviewSync(); ?></b>
                         </p>
                     </fieldset>
                 </td>
@@ -195,11 +195,11 @@
 </form>
 <script>
     function triggerManualSync() {
-        <?php $nonce = wp_create_nonce($plugin->getManualSyncNonce());?>
+        <?php $nonce = wp_create_nonce($plugin->woocommerce->getManualSyncNonce());?>
         jQuery.ajax({
             type: "post",
             url: "admin-ajax.php",
-            data: {action: <?= json_encode($plugin->getManualSyncAction()); ?>, _ajax_nonce: '<?php echo $nonce; ?>'},
+            data: {action: <?= json_encode($plugin->woocommerce->getManualSyncAction()); ?>, _ajax_nonce: '<?php echo $nonce; ?>'},
             success: function (response) {
                 const obj = JSON.parse(response);
                 if (obj.status) {

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -142,7 +142,7 @@
                     </fieldset>
                     <fieldset>
                         <label>
-                            <button type="button" id="<?= $plugin->getOptionName('manual_sync_btn'); ?>" onClick="triggerManualSync()">
+                            <button class="button" type="button" id="<?= $plugin->getOptionName('manual_sync_btn'); ?>" onClick="triggerManualSync()">
                                 <?= __('Sync manually', 'webwinkelkeur'); ?>
                             </button>
                             <span id='successful-sync' hidden style="color:#0ED826">&#10003;
@@ -159,18 +159,17 @@
             <tr>
                 <th scope="row"></th>
                 <td>
-                    <label>
-                        GTIN/EAN key
-                        <select name="<?= $plugin->getOptionName('custom_gtin'); ?>">
-                            <option value=""><?= $plugin->getActiveGtinPlugin() ? __('Automatic detection', 'webwinkelkeur') . ' (' . (explode('/', $plugin->getActiveGtinPlugin())[0] ?? '') . ')' : 'Select key'; ?></option>
-                            <optgroup label="<?= _e('Suggested keys', 'webwinkelkeur'); ?>">
-                                <?= $plugin->getSelectOptions($config['custom_gtin'], true); ?>
-                            </optgroup>
-                            <optgroup label="<?= _e('Other keys', 'webwinkelkeur'); ?>">
-                                <?= $plugin->getSelectOptions($config['custom_gtin']); ?>
-                            </optgroup>
-                        </select>
-                    </label>
+                    <label>GTIN/EAN key</label>
+                    <select name="<?= $plugin->getOptionName('custom_gtin'); ?>">
+                        <option value=""><?= $plugin->getActiveGtinPlugin() ? __('Automatic detection', 'webwinkelkeur') . ' (' . (explode('/', $plugin->getActiveGtinPlugin())[0] ?? '') . ')' : 'Select key'; ?></option>
+                        <optgroup label="<?= _e('Suggested keys', 'webwinkelkeur'); ?>">
+                            <?= $plugin->getSelectOptions($config['custom_gtin'], true); ?>
+                        </optgroup>
+                        <optgroup label="<?= _e('Other keys', 'webwinkelkeur'); ?>">
+                            <?= $plugin->getSelectOptions($config['custom_gtin']); ?>
+                        </optgroup>
+                    </select>
+
                     <p class="description">
                         <?=
                         __('Tell this plugin where to find the product <strong>GTIN</strong> by selecting a custom key. For example: if you use a field called <strong>_productcode</strong> to store the <strong>GTIN</strong>, you should select  <strong>_product_code</strong>. Our plugin also supports certain 3rd party plugins. If we found a supported plugin, this box is set to <strong>Automatic detection</strong>, you can still choose to select another key.', 'webwinkelkeur')

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -169,7 +169,6 @@
                             <?= $plugin->getSelectOptions($config['custom_gtin']); ?>
                         </optgroup>
                     </select>
-
                     <p class="description">
                         <?=
                         __('Tell this plugin where to find the product <strong>GTIN</strong> by selecting a custom key. For example: if you use a field called <strong>_productcode</strong> to store the <strong>GTIN</strong>, you should select  <strong>_product_code</strong>. Our plugin also supports certain 3rd party plugins. If we found a supported plugin, this box is set to <strong>Automatic detection</strong>, you can still choose to select another key.', 'webwinkelkeur')
@@ -213,4 +212,3 @@
         });
     }
 </script>
-<?php

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -201,7 +201,10 @@
         jQuery.ajax({
             type: "post",
             url: "admin-ajax.php",
-            data: {action: <?= json_encode($plugin->woocommerce->getManualSyncAction()); ?>, _ajax_nonce: '<?php echo $nonce; ?>'},
+            data: <?= json_encode([
+                'action' => $plugin->woocommerce->getManualSyncAction(),
+                '_ajax_nonce' => $nonce,
+            ]); ?>,
             success: function (response) {
                 const obj = JSON.parse(response);
                 if (obj.status) {

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -148,8 +148,11 @@
                             <span id='successful-sync' hidden style="color:#0ED826">&#10003;
                                 <?= __('Synced successfully', 'webwinkelkeur'); ?>
                             </span>
-                        </label>
-                            <?= __('Next automatic sync', 'webwinkelkeur'); ?>:<?= esc_html($plugin->getNextReviewSync()); ?>
+                        </label> </br>
+                        <p> <?= __('Last sync', 'webwinkelkeur'); ?>: <b><?= $plugin->getLastReviewSync(); ?></b>
+                        </p>
+                        <p> <?= __('Next sync', 'webwinkelkeur'); ?>: <b><?= $plugin->getNextReviewSync(); ?></b>
+                        </p>
                     </fieldset>
                 </td>
             </tr>

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -159,16 +159,18 @@
             <tr>
                 <th scope="row"></th>
                 <td>
-                    <label>GTIN/EAN key</label>
-                    <select name="<?= $plugin->getOptionName('custom_gtin'); ?>">
-                        <option value=""><?= $plugin->getActiveGtinPlugin() ? __('Automatic detection', 'webwinkelkeur') . ' (' . (explode('/', $plugin->getActiveGtinPlugin())[0] ?? '') . ')' : 'Select key'; ?></option>
-                        <optgroup label="<?= _e('Suggested keys', 'webwinkelkeur'); ?>">
-                            <?= $plugin->getSelectOptions($config['custom_gtin'], true); ?>
-                        </optgroup>
-                        <optgroup label="<?= _e('Other keys', 'webwinkelkeur'); ?>">
-                            <?= $plugin->getSelectOptions($config['custom_gtin']); ?>
-                        </optgroup>
-                    </select>
+                    <label>
+                        GTIN/EAN key
+                        <select name="<?= $plugin->getOptionName('custom_gtin'); ?>">
+                            <option value=""><?= $plugin->getActiveGtinPlugin() ? __('Automatic detection', 'webwinkelkeur') . ' (' . (explode('/', $plugin->getActiveGtinPlugin())[0] ?? '') . ')' : 'Select key'; ?></option>
+                            <optgroup label="<?= _e('Suggested keys', 'webwinkelkeur'); ?>">
+                                <?= $plugin->getSelectOptions($config['custom_gtin'], true); ?>
+                            </optgroup>
+                            <optgroup label="<?= _e('Other keys', 'webwinkelkeur'); ?>">
+                                <?= $plugin->getSelectOptions($config['custom_gtin']); ?>
+                            </optgroup>
+                        </select>
+                    </label>
                     <p class="description">
                         <?=
                         __('Tell this plugin where to find the product <strong>GTIN</strong> by selecting a custom key. For example: if you use a field called <strong>_productcode</strong> to store the <strong>GTIN</strong>, you should select  <strong>_product_code</strong>. Our plugin also supports certain 3rd party plugins. If we found a supported plugin, this box is set to <strong>Automatic detection</strong>, you can still choose to select another key.', 'webwinkelkeur')

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -148,7 +148,7 @@
                             <span id='successful-sync' hidden style="color:#0ED826">&#10003;
                                 <?= __('Synced successfully', 'webwinkelkeur'); ?>
                             </span>
-                        </label> </br>
+                        </label> <br>
                         <p> <?= __('Last sync', 'webwinkelkeur'); ?>: <b><?= $plugin->woocommerce->getLastReviewSync(); ?></b>
                         </p>
                         <p> <?= __('Next sync', 'webwinkelkeur'); ?>: <b><?= $plugin->woocommerce->getNextReviewSync(); ?></b>

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -206,8 +206,7 @@
                 '_ajax_nonce' => $nonce,
             ]); ?>,
             success: function (response) {
-                const obj = JSON.parse(response);
-                if (obj.status) {
+                if (response.status) {
                     jQuery("#successful-sync").show();
                 } else {
                     alert('Something went wrong with syncing.');

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -140,6 +140,17 @@
                             </p>
                         </label>
                     </fieldset>
+                    <fieldset>
+                        <label>
+                            <button type="button" id="<?= $plugin->getOptionName('manual_sync_btn'); ?>" onClick="triggerManualSync()">
+                                <?= __('Sync manually', 'webwinkelkeur'); ?>
+                            </button>
+                            <span id='successful-sync' hidden style="color:#0ED826">&#10003;
+                                <?= __('Synced successfully', 'webwinkelkeur'); ?>
+                            </span>
+                        </label>
+                            <?= __('Next automatic sync', 'webwinkelkeur'); ?>:<?= esc_html($plugin->getNextReviewSync()); ?>
+                    </fieldset>
                 </td>
             </tr>
             <tr>
@@ -181,3 +192,23 @@
         <?php submit_button(); ?>
     </div>
 </form>
+<script>
+    function triggerManualSync() {
+        <?php $nonce = wp_create_nonce($plugin->getManualSyncNonce());?>
+        jQuery.ajax({
+            type: "post",
+            url: "admin-ajax.php",
+            data: {action: <?= json_encode($plugin->getManualSyncAction()); ?>, _ajax_nonce: '<?php echo $nonce; ?>'},
+            success: function (response) {
+                const obj = JSON.parse(response);
+                if (obj.status) {
+                    jQuery("#successful-sync").show();
+                } else {
+                    alert('Something went wrong with syncing.');
+                }
+                console.log(response);
+            }
+        });
+    }
+</script>
+<?php

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -142,7 +142,7 @@
                     </fieldset>
                     <fieldset>
                         <label>
-                            <button class="button" type="button" id="<?= $plugin->getOptionName('manual_sync_btn'); ?>" onClick="triggerManualSync()">
+                            <button class="button" <?= !$config['product_reviews'] ? 'disabled' : ''; ?> type="button" id="<?= $plugin->getOptionName('manual_sync_btn'); ?>" onClick="triggerManualSync()">
                                 <?= __('Sync manually', 'webwinkelkeur'); ?>
                             </button>
                             <span id='successful-sync' hidden style="color:#0ED826">&#10003;


### PR DESCRIPTION
https://app.clubhouse.io/webwinkelkeur/story/5556/add-button-for-manually-syncing-product-reviews-in-woocommerce

Changes made: 
 - add a button that makes an ajax call to trigger review sync
 - indicate if manual sync was successful 
 - add last sync and next sync date 
 - minor improvements to front-end

[ch5556]