### PR TITLE
Add yoast support

### DIFF
--- a/common/src/GtinHandler.php
+++ b/common/src/GtinHandler.php
@@ -4,20 +4,35 @@ namespace Valued\WordPress;
 
 class GtinHandler {
     const SUPPORTED_PLUGINS = [
-        'woosa-vandermeer/woosa-vandermeer.php' => ['vdm_ean'],
+        'woosa-vandermeer/woosa-vandermeer.php' => [
+            'handler' => 'getFromPluginMeta',
+            'arguments' => ['vdm_ean'],
+        ],
         'wpseo-woocommerce/wpseo-woocommerce.php' => [
-            'gtin13',
-            'gtin8',
-            'gtin12',
-            'gtin14',
-            'isbn',
+            'handler' => 'handleWpseoPlugin',
+            'arguments' => [
+                'gtin13',
+                'gtin8',
+                'gtin12',
+                'gtin14',
+                'isbn',
+            ],
         ],
-        'woocommerce-product-feeds/woocommerce-gpf.php' => null,
-        'customer-reviews-woocommerce/ivole.php' => ['_cr_gtin'],
+        'woocommerce-product-feeds/woocommerce-gpf.php' => [
+            'handler' => 'handleGpfPlugin',
+        ],
+        'customer-reviews-woocommerce/ivole.php' => [
+            'handler' => 'getFromPluginMeta',
+            'arguments' => ['_cr_gtin'],
+        ],
         'product-gtin-ean-upc-isbn-for-woocommerce/product-gtin-ean-upc-isbn-for-woocommerce.php' => [
-            '_wpm_gtin_code', '_wpm_ean_code'
+            'handler' => 'getFromPluginMeta',
+            'arguments' => ['_wpm_gtin_code', '_wpm_ean_code'],
         ],
-        'woo-product-feed-pro/woocommerce-sea.php' => ['_woosea_gtin', '_woosea_ean'],
+        'woo-product-feed-pro/woocommerce-sea.php' => [
+            'handler' => 'getFromPluginMeta',
+            'arguments' => ['_woosea_gtin', '_woosea_ean'],
+        ],
     ];
     const ATTRIBUTE_PREFIX = 'custom_attribute';
     const META_PREFIX = 'meta_key';
@@ -46,15 +61,10 @@ class GtinHandler {
         if (!empty($custom_gtin_key)) {
             return $this->getGtinFromKey($custom_gtin_key);
         }
-        if (function_exists('woocommerce_gpf_show_element')) {
-            return (string) woocommerce_gpf_show_element('gtin', $this->product->post) ?: null;
-        }
-        if (!is_plugin_active('wpseo-woocommerce/wpseo-woocommerce.php')) {
-            return $this->handleWpseoPlugin();
-        }
-        foreach (self::SUPPORTED_PLUGINS as $plugin_name => $keys) {
-            if ($keys && is_plugin_active($plugin_name)) {
-                return $this->getFromPluginMeta($keys);
+        foreach (self::SUPPORTED_PLUGINS as $plugin_name => $data) {
+            if (is_plugin_active($plugin_name)) {
+                $func = self::SUPPORTED_PLUGINS[$plugin_name]['handler'];
+                return $this->$func(self::SUPPORTED_PLUGINS[$plugin_name]['arguments']?? null);
             }
         }
         return $this->getGtinFromMeta($this->gtin_meta_key);
@@ -87,11 +97,18 @@ class GtinHandler {
         return null;
     }
 
-    private function handleWpseoPlugin() {
-        $keys = get_post_meta($this->product->get_id(), 'wpseo_global_identifier_values')[0] ?? null;
-        foreach (self::SUPPORTED_PLUGINS['wpseo-woocommerce/wpseo-woocommerce.php'] as $gtin_key) {
-            if (!empty($keys[$gtin_key])) {
-                return (string) $keys[$gtin_key];
+    private function handleGpfPlugin() {
+        if (function_exists('woocommerce_gpf_show_element')) {
+            return (string) woocommerce_gpf_show_element('gtin', $this->product->post) ?: null;
+        }
+        return null;
+    }
+
+    private function handleWpseoPlugin($keys) {
+        $meta_values = get_post_meta($this->product->get_id(), 'wpseo_global_identifier_values')[0] ?? null;
+        foreach ($keys as $gtin_key) {
+            if (!empty($meta_values[$gtin_key])) {
+                return (string) $meta_values[$gtin_key];
             }
         }
         return null;


### PR DESCRIPTION
https://app.clubhouse.io/webwinkelkeur/story/6639/add-support-for-gtin-detection-from-yoast-plugin
Add support for https://yoast.com/wordpress/plugins/yoast-woocommerce-seo/
This plugin differentiates by having multiple keys stored in the `post_meta` value, because of that I decided to go again with the solution of storing the functions for handling the different plugins inside the `SUPPORTED_PLUGINS` array. Otherwise, `getGtin` function becomes filled with conditions. I don't think the new solution is perfect, we have already discussed that this should be avoided when can.
Initially, I started with something like e422007 

[ch6639]

