### PR TITLE
Fix condition for showing the custom GTIN field

### DIFF
--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -176,8 +176,8 @@ class WooCommerce {
             $gtin_handler->getActivePlugin()
             || !$this->isProductReviewsEnabled()
             || (
-                !empty($this->plugin->getOption('custom_gtin'))
-                && $this->plugin->getOption('custom_gtin') != 'meta_key' . $this->getGtinMetaKey()
+                $this->plugin->getOption('custom_gtin')
+                && $this->plugin->getOption('custom_gtin') != GtinHandler::META_PREFIX . $this->getGtinMetaKey()
             )
         ) {
             return;

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -175,7 +175,10 @@ class WooCommerce {
         if (
             $gtin_handler->getActivePlugin()
             || !$this->isProductReviewsEnabled()
-            || $this->plugin->getOption('custom_gtin') != $this->getGtinMetaKey()
+            || (
+                !empty($this->plugin->getOption('custom_gtin'))
+                && $this->plugin->getOption('custom_gtin') != 'meta_key' . $this->getGtinMetaKey()
+            )
         ) {
             return;
         }


### PR DESCRIPTION
Custom `GTIN` field should show when no `key` is select or when selected `key` is equal to our `custom key`

[ch9268]