### PR TITLE
Update product ratings

### DIFF
--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -395,8 +395,8 @@ class WooCommerce {
                 throw new RuntimeException(
                     "Could not insert review for product: {$comment_data['comment_post_ID']}");
             }
+            WC_Comments::clear_transients($comment_data['comment_post_ID']);
         }
-        WC_Comments::clear_transients($comment_data['comment_post_ID']);
     }
 
     private function getExistingComment(int $post_id, string $author_email, int $review_id) {

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -7,6 +7,7 @@ use RuntimeException;
 use WC_Customer;
 use WC_Product_Factory;
 use WP_Comment_Query;
+use WC_Comments;
 
 class WooCommerce {
     const DEFAULT_ORDER_STATUS = ['wc-completed'];
@@ -395,6 +396,7 @@ class WooCommerce {
                     "Could not insert review for product: {$comment_data['comment_post_ID']}");
             }
         }
+        WC_Comments::clear_transients($comment_data['comment_post_ID']);
     }
 
     private function getExistingComment(int $post_id, string $author_email, int $review_id) {


### PR DESCRIPTION
### Update product ratings stats
https://woocommerce.github.io/code-reference/classes/WC-Comments.html#method_clear_transients
`clear_transients()`
> Ensure product average rating and review count is kept up to date.

An out-of-date rating_counts might lead to `woocommerce-product-rating` not being displayed.
https://github.com/woocommerce/woocommerce/blob/b19500728b4b292562afb65eb3a0c0f50d5859de/templates/single-product/rating.php#L28

[ch10735]