### PR TITLE
Fix PHP warning

### DIFF
--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -88,7 +88,7 @@ class WooCommerce {
 
         $order_number = $order->get_order_number();
 
-        $email = get_post_meta($order_id, '_billing_email', true);
+        $email = $order->get_billing_email();
         if (!preg_match('|@|', $email)) {
             return;
         }


### PR DESCRIPTION
Retrieve billing_email directly from `WC_Order`
PHP message: billing_email was called incorrectly. Order properties should not be accessed directly.

[ch11731]