### PR TITLE
Delete no expiration transient

### DIFF
--- a/common/src/Frontend.php
+++ b/common/src/Frontend.php
@@ -88,6 +88,10 @@ class Frontend {
 
         $transient = implode(':', [$this->plugin->getSlug(), 'rich_snippet', md5($url)]);
 
+	    if (!get_option('_transient_timeout_' . $transient, 0)) {
+		    delete_transient($transient);
+	    }
+
         if ($result = get_transient($transient)) {
             return $result;
         }

--- a/common/src/Frontend.php
+++ b/common/src/Frontend.php
@@ -88,13 +88,10 @@ class Frontend {
 
         $transient = implode(':', [$this->plugin->getSlug(), 'rich_snippet', md5($url)]);
 
-	    if (!get_option('_transient_timeout_' . $transient, 0)) {
-		    delete_transient($transient);
+	    $data = get_transient($transient);
+	    if (is_array($data) && !empty($data[0]) && $data[0] > time()) {
+		    return $data[1];
 	    }
-
-        if ($result = get_transient($transient)) {
-            return $result;
-        }
 
         try {
             $result = $this->fetchRichSnippet($url);
@@ -102,7 +99,7 @@ class Frontend {
             return $this->log_error($e->getMessage());
         }
 
-        set_transient($transient, $result, 7200);
+	    set_transient($transient, [time() + 7200, $result], 7200);
 
         return $result;
     }

--- a/common/src/Frontend.php
+++ b/common/src/Frontend.php
@@ -88,10 +88,10 @@ class Frontend {
 
         $transient = implode(':', [$this->plugin->getSlug(), 'rich_snippet', md5($url)]);
 
-	    $data = get_transient($transient);
-	    if (is_array($data) && !empty($data[0]) && $data[0] > time()) {
-		    return $data[1];
-	    }
+        $data = get_transient($transient);
+        if (is_array($data) && !empty($data[0]) && $data[0] > time()) {
+            return $data[1];
+        }
 
         try {
             $result = $this->fetchRichSnippet($url);
@@ -99,7 +99,7 @@ class Frontend {
             return $this->log_error($e->getMessage());
         }
 
-	    set_transient($transient, [time() + 7200, $result], 7200);
+        set_transient($transient, [time() + 7200, $result], 7200);
 
         return $result;
     }


### PR DESCRIPTION
### Fix richsnippet
A webshop rich snippet data hasn't been updated for over 5 months - https://www.cbddrogist.nl

I believe the reason is the `transient` has become with no expiration.
I researched and found multiple reports where a transient expiration becomes 0 - no expiration, yet I could not find why this happens- there is a case where it happened after database migration, other suggestions are 3rd party plugins.  [similar issue](https://wordpress.stackexchange.com/questions/210575/what-causes-a-transient-to-changes-status-to-does-not-expire)

I am in contact with the webshop to find out what the transient values are.

[sc-15764]