### PR TITLE
Rich snippet language

### DIFF
--- a/common/src/Frontend.php
+++ b/common/src/Frontend.php
@@ -83,7 +83,7 @@ class Frontend {
         $locale = explode('_', get_locale());
         $params = http_build_query([
             'id'   => $this->wwk_shop_id,
-            'lang' => $locale[0] ?? null,
+            'lang' => $locale[0],
         ]);
         $url = sprintf(
             'https://%s/webshops/rich_snippet?%s',

--- a/common/src/Frontend.php
+++ b/common/src/Frontend.php
@@ -80,10 +80,15 @@ class Frontend {
     }
 
     private function get_rich_snippet() {
+        $locale = explode('_', get_locale());
+        $params = http_build_query([
+            'id'   => $this->wwk_shop_id,
+            'lang' => $locale[0] ?? null,
+        ]);
         $url = sprintf(
-            'https://%s/webshops/rich_snippet?id=%d',
+            'https://%s/webshops/rich_snippet?%s',
             $this->plugin->getDashboardDomain(),
-            (int) $this->wwk_shop_id
+            $params
         );
 
         $transient = implode(':', [$this->plugin->getSlug(), 'rich_snippet', md5($url)]);


### PR DESCRIPTION
Without sending the lang parameter to `/rich_snippet` the language is always Dutch, even if the webshop does not have Dutch language enabled. 
https://github.com/webwinkelkeur/dash/blob/a860295fc4cec4fc34f6e828364029f5c6dc6889/app/Controller/WebshopsController.php#L3240
I think this should also be adjusted in the dashboard to take the webshop default language instead of the system.

