### PR TITLE
Fix product variations sync

### DIFF
--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -445,7 +445,7 @@ class WooCommerce {
             throw new RuntimeException(sprintf("No product with ID {$product_id}"));
         }
 
-        if ($product->get_parent_id() !== 0) {
+        if ($product->get_parent_id()) {
             $product_id = $product->get_parent_id();
         }
 

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -440,9 +440,15 @@ class WooCommerce {
     private function getCommentData(\SimpleXMLElement $review) {
         $pf = new WC_Product_Factory();
         $product_id = (int) $review->products->product->external_id;
-        if (!$pf->get_product($product_id)) {
+
+        if (!$product = $pf->get_product($product_id)) {
             throw new RuntimeException(sprintf("No product with ID {$product_id}"));
         }
+
+        if ($product->get_parent_id() !== 0) {
+            $product_id = $product->get_parent_id();
+        }
+
         $author_email = sanitize_text_field((string) $review->email);
         return [
             'comment_post_ID' => $product_id,


### PR DESCRIPTION
Use main product to sync product reviews.
WooCommerce stores product reviews for variations under the main product.