### PR TITLE
Multisite reviews

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+= 3.33 - 2024-01-23 =
+* Support review sync in Multisite setup
+
 = 3.32 - 2023-12-11 =
 * Save reviews in the parent product of a variation, if available.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 = 3.33 - 2024-01-23 =
-* Support review sync in Multisite setup
+* Support review sync in multisite setup.
 
 = 3.32 - 2023-12-11 =
 * Save reviews in the parent product of a variation, if available.

--- a/common/src/Admin.php
+++ b/common/src/Admin.php
@@ -56,6 +56,7 @@ class Admin {
             'invite_delay' => 'intval',
             'limit_order_data' => 'boolval',
             'product_reviews' => 'boolval',
+            'product_reviews_multisite' => 'boolval',
             'javascript' => 'boolval',
             'order_statuses' => function ($value) {
                 return array_map('strval', is_array($value) ? $value : []);

--- a/common/src/WooCommerce.php
+++ b/common/src/WooCommerce.php
@@ -698,12 +698,12 @@ class WooCommerce {
         return $invite_delay;
     }
 
-    private function getProductImage(string $image_id): ?string {
+    private function getProductImage(string $image_id) {
         $image_array = wp_get_attachment_image_src($image_id);
         return $image_array[0] ?? null;
     }
 
-    private function failedInsertError(int $product_id): void {
+    private function failedInsertError(int $product_id) {
         throw new RuntimeException(
             "Could not insert review for product: {$product_id}");
     }

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -155,7 +155,7 @@ use Valued\WordPress\WooCommerce;
                                 echo 'checked ';
                             } ?> />
                             <?= esc_html(
-                                __('Sync to Multi-site', 'webwinkelkeur')
+                                __('Sync to Multisite', 'webwinkelkeur')
                             ); ?>
                             <p class="description">
                                 <?= esc_html(

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -151,6 +151,21 @@ use Valued\WordPress\WooCommerce;
                     </fieldset>
                     <fieldset>
                         <label>
+                            <input type="checkbox" name="<?= $plugin->getOptionName('product_reviews_multisite'); ?>" value="1" <?php if ($config['product_reviews_multisite']) {
+                                echo 'checked ';
+                            } ?> />
+                            <?= esc_html(
+                                __('Sync to Multi-site', 'webwinkelkeur')
+                            ); ?>
+                            <p class="description">
+                                <?= esc_html(
+                                    sprintf(__('Enable sync product reviews to multisite setup. Product will be matched by ID and SKU.', 'webwinkelkeur'), $plugin->getName())
+                                ); ?>
+                            </p>
+                        </label>
+                    </fieldset>
+                    <fieldset>
+                        <label>
                             <button class="button webwinkelkeur-sync-btn" type="button"
                                     <?= !$config['product_reviews'] ? 'disabled' : ''; ?>
                             >

--- a/common/templates/options.php
+++ b/common/templates/options.php
@@ -151,9 +151,7 @@ use Valued\WordPress\WooCommerce;
                     </fieldset>
                     <fieldset>
                         <label>
-                            <input type="checkbox" name="<?= $plugin->getOptionName('product_reviews_multisite'); ?>" value="1" <?php if ($config['product_reviews_multisite']) {
-                                echo 'checked ';
-                            } ?> />
+                            <input type="checkbox" name="<?= $plugin->getOptionName('product_reviews_multisite'); ?>" value="1" <?= $config['product_reviews_multisite'] ? 'checked' : ''; ?> />
                             <?= esc_html(
                                 __('Sync to Multisite', 'webwinkelkeur')
                             ); ?>


### PR DESCRIPTION
This PR adds support for syncing product reviews to [Wordpress Multisite](https://developer.wordpress.org/advanced-administration/multisite/create-network/). In wordpress multisites, the product IDs are not unique.



[sc-37278]